### PR TITLE
Prevent user with empty uid

### DIFF
--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -4,6 +4,7 @@
  * @author Joas Schilling <coding@schilljs.com>
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
  *
  * @copyright Copyright (c) 2016, ownCloud GmbH.
  * @license AGPL-3.0
@@ -109,6 +110,12 @@ class User {
 	public function __construct($username, $dn, IUserTools $access,
 		IConfig $config, FilesystemHelper $fs, Image $image,
 		LogWrapper $log, IAvatarManager $avatarManager, IUserManager $userManager) {
+
+		if ($username === null) {
+			throw new \InvalidArgumentException("uid for '$dn' must not be null!");
+		} else if ($username === '') {
+			throw new \InvalidArgumentException("uid for '$dn' must not be an empty string!");
+		}
 
 		$this->access        = $access;
 		$this->connection    = $access->getConnection();


### PR DESCRIPTION
The uid might be empty if the mapped owncloud_username, eg. mail is empty. While admins should make   sure the attribute is always set the ldap admins are only human. Errors happen and we need to protect against user errer. In this case we should die hard, giving everyone a hint at what might be wrong, which is why I use assert(). It will throw an exception and prevent further desaster. As in overwriting the quota for all users ...
 