### PR TITLE
Allow specifying the prefix for occ ldap:create-empty-config

### DIFF
--- a/lib/Command/CreateEmptyConfig.php
+++ b/lib/Command/CreateEmptyConfig.php
@@ -25,6 +25,7 @@
 namespace OCA\User_LDAP\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use \OCA\User_LDAP\Helper;
@@ -46,19 +47,33 @@ class CreateEmptyConfig extends Command {
 		$this
 			->setName('ldap:create-empty-config')
 			->setDescription('creates an empty LDAP configuration')
+			->addArgument(
+				'configID',
+				InputArgument::OPTIONAL,
+				'create a configuration with the specified id'
+			)
 		;
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$configPrefix = $this->getNewConfigurationPrefix();
+		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
+		$configID = $input->getArgument('configID');
+		if(is_null($configID)) {
+			$configPrefix = $this->getNewConfigurationPrefix($availableConfigs);
+		} else {
+			if(in_array($configID, $availableConfigs)) {
+				$output->writeln("configID already exists");
+				return;
+			}
+			$configPrefix = $configID;
+		}
 		$output->writeln("Created new configuration with configID '{$configPrefix}'");
 
 		$configHolder = new Configuration($configPrefix);
 		$configHolder->saveConfiguration();
 	}
 
-	protected function getNewConfigurationPrefix() {
-		$serverConnections = $this->helper->getServerConfigurationPrefixes();
+	protected function getNewConfigurationPrefix(array $serverConnections) {
 
 		sort($serverConnections);
 		$lastKey = array_pop($serverConnections);

--- a/lib/Command/CreateEmptyConfig.php
+++ b/lib/Command/CreateEmptyConfig.php
@@ -61,9 +61,15 @@ class CreateEmptyConfig extends Command {
 		if(is_null($configID)) {
 			$configPrefix = $this->getNewConfigurationPrefix($availableConfigs);
 		} else {
-			if(in_array($configID, $availableConfigs)) {
+			// Check we are not trying to create an empty configid
+			if($configID === '') {
+				$output->writeln("configID cannot be empty");
+				return 1;
+			}
+			// Check if we are not already using this configid
+			if(in_array($configID, $availableConfigs, true)) {
 				$output->writeln("configID already exists");
-				return;
+				return 1;
 			}
 			$configPrefix = $configID;
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please fill out below information carefully.

Please note that any kind of change first has to be submitted to the master branch which holds the next major version of ownCloud.

We will carefully discuss if your change can or has to be backported to stable branches.
-->
## Description

Adds an optional `configId` param to `occ ldap:create-empty-config`
## Related Issue

<!--- This project only accepts pull requests related to open issues -->

<!--- If suggesting a new feature or change, please discuss it in an issue first -->

<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->

<!--- Please link to the issue here: -->

new feature
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

It improves scriptability of ldap setups, eg for automated testing with multiple ldap servers
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

locally, juggling 7 ldap servers, writing a script that automatically sets up the connections
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
  The configuration class and user_ldap does not yet use DI ... makes it hard to write a unit test. oh well
- [ ] All new and existing tests passed.
