### PR TITLE
array_merge does not merge keys correctly

### DIFF
--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -223,13 +223,17 @@ class Group_LDAP extends BackendUtility implements \OCP\GroupInterface {
 				if (!empty($nestedGroups)) {
 					$subMembers = $this->_groupMembers($memberDN, $seen);
 					if ($subMembers) {
-						$allMembers = array_merge($allMembers, $subMembers);
+						// $allMembers = array_merge($allMembers, $subMembers);
+						// Fix for key merge
+						$allMembers = $allMembers + $subMembers;
 					}
 				}
 			}
 		}
 		
-		$allMembers = array_merge($allMembers, $this->getDynamicGroupMembers($dnGroup));
+		// $allMembers = array_merge($allMembers, $this->getDynamicGroupMembers($dnGroup));
+		// Fix for key merge
+		$allMembers = $allMembers + $this->getDynamicGroupMembers($dnGroup);
 		
 		$this->access->connection->writeToCache($cacheKey, $allMembers);
 		return $allMembers;


### PR DESCRIPTION
When you are using user ID-s as numeric and using numeric ID-s in keys then array_merge does not merge correctly.
Reference: https://github.com/owncloud/core/issues/13378
