### PR TITLE
add empty function composeAndStoreDisplayName

### DIFF
--- a/lib/User/OfflineUser.php
+++ b/lib/User/OfflineUser.php
@@ -227,4 +227,17 @@ class OfflineUser {
 
 		$this->hasActiveShares = false;
 	}
+	
+	/**
+	 * Adding empty function to OfflineUser to avoid throwing error "function missing".
+	 * Composes the display name and stores it in the database. The final
+	 * display name is returned.
+	 *
+	 * @param string $displayName
+	 * @param string $displayName2
+	 * @returns string the effective display name
+	 */
+	public function composeAndStoreDisplayName($displayName, $displayName2 = '') {
+		return $displayName;
+	}
 }


### PR DESCRIPTION
@jvillafanez @PVince81 

Adding an empty function to avoid "missing function" error, which is an issue in https://github.com/owncloud/enterprise/issues/1686


