### PR TITLE
set default quota when no ldap attribute is defined

### DIFF
--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -170,8 +170,11 @@ class User {
 
 		//Email
 		$attr = strtolower($this->connection->ldapEmailAttribute);
+		$quotaDefault = $this->connection->ldapQuotaDefault;
 		if(isset($ldapEntry[$attr])) {
 			$this->updateEmail($ldapEntry[$attr][0]);
+		} else if (!empty($quotaDefault)) {
+			$this->updateQuota();
 		}
 		unset($attr);
 


### PR DESCRIPTION
Without this a default quota is only eventually updated. It should be updated on login.

cc @dercorn