### PR TITLE
Correctly apply quota

### DIFF
--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -494,11 +494,16 @@ class User {
 			}
 		}
 
-		if($quota !== false) {
-			$this->userManager->get($this->uid)->setQuota($quota);
+		$targetUser = $this->userManager->get($this->uid);
+		if ($targetUser) {
+			if($quota !== false) {
+				$targetUser->setQuota($quota);
+			} else {
+				$this->log->log('not suitable default quota found for user ' . $this->uid . ': [' . $defaultQuota . ']', \OCP\Util::WARN);
+				$targetUser->setQuota('default');
+			}
 		} else {
-			$this->log->log('not suitable default quota found for user ' . $this->uid . ': [' . $defaultQuota . ']', \OCP\Util::WARN);
-			$this->userManager->get($this->uid)->setQuota('default');
+			$this->log->log('trying to set a quota for user ' . $this->uid . ' but the user is missing', \OCP\Util::ERROR);
 		}
 	}
 

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -455,6 +455,20 @@ class User {
 	}
 
 	/**
+	 * Overall process goes as follow:
+	 * 1. fetch the quota from LDAP and check if it's parseable with the "verifyQuotaValue" function
+	 * 2. if the value can't be fetched, is empty or not parseable, use the default LDAP quota
+	 * 3. if the default LDAP quota can't be parsed, use the ownCloud's default quota (use 'default')
+	 * 4. check if the target user exists and set the quota for the user.
+	 *
+	 * In order to improve performance and prevent an unwanted extra LDAP call, the $valueFromLDAP
+	 * parameter can be passed with the value of the attribute. This value will be considered as the
+	 * quota for the user coming from the LDAP server (step 1 of the process) It can be useful to
+	 * fetch all the user's attributes in one call and use the fetched values in this function.
+	 * The expected value for that parameter is a string describing the quota for the user. Valid
+	 * values are 'none' (unlimited), 'default' (the ownCloud's default quota), '1234' (quota in
+	 * bytes), '1234 MB' (quota in MB - check the \OC_Helper::computerFileSize method for more info)
+	 *
 	 * fetches the quota from LDAP and stores it as ownCloud user value
 	 * @param string $valueFromLDAP the quota attribute's value can be passed,
 	 * to save the readAttribute request

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -165,6 +165,10 @@ class User {
 		$attr = strtolower($this->connection->ldapQuotaAttribute);
 		if(isset($ldapEntry[$attr])) {
 			$this->updateQuota($ldapEntry[$attr][0]);
+		} else {
+			if ($this->connection->ldapQuotaDefault !== '') {
+				$this->updateQuota();
+			}
 		}
 		unset($attr);
 
@@ -460,23 +464,46 @@ class User {
 		if($this->wasRefreshed('quota')) {
 			return;
 		}
-		//can be null
-		$quotaDefault = $this->connection->ldapQuotaDefault;
-		$quota = $quotaDefault !== '' ? $quotaDefault : null;
-		$quota = !is_null($valueFromLDAP) ? $valueFromLDAP : $quota;
 
+		$quota = false;
 		if(is_null($valueFromLDAP)) {
 			$quotaAttribute = $this->connection->ldapQuotaAttribute;
 			if ($quotaAttribute !== '') {
 				$aQuota = $this->access->readAttribute($this->dn, $quotaAttribute);
 				if($aQuota && (count($aQuota) > 0)) {
-					$quota = $aQuota[0];
+					if ($this->verifyQuotaValue($aQuota[0])) {
+						$quota = $aQuota[0];
+					} else {
+						$this->log->log('not suitable LDAP quota found for user ' . $this->uid . ': [' . $aQuota[0] . ']', \OCP\Util::WARN);
+					}
 				}
 			}
+		} else {
+			if ($this->verifyQuotaValue($valueFromLDAP)) {
+				$quota = $valueFromLDAP;
+			} else {
+				$this->log->log('not suitable LDAP quota found for user ' . $this->uid . ': [' . $valueFromLDAP . ']', \OCP\Util::WARN);
+			}
 		}
-		if(!is_null($quota)) {
+
+		if ($quota === false) {
+			// quota not found using the LDAP attribute (or not parseable). Try the default quota
+			$defaultQuota = $this->connection->ldapQuotaDefault;
+			if ($this->verifyQuotaValue($defaultQuota)) {
+				$quota = $defaultQuota;
+			}
+		}
+
+		if($quota !== false) {
 			$this->userManager->get($this->uid)->setQuota($quota);
+		} else {
+			$this->log->log('not suitable default quota found for user ' . $this->uid . ': [' . $defaultQuota . ']', \OCP\Util::WARN);
+			$this->userManager->get($this->uid)->setQuota('default');
 		}
+	}
+
+	private function verifyQuotaValue($quotaValue) {
+		return $quotaValue === 'none' || $quotaValue === 'default' || \OC_Helper::computerFileSize($quotaValue) !== false;
 	}
 
 	/**

--- a/tests/User/UserTest.php
+++ b/tests/User/UserTest.php
@@ -199,15 +199,17 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue('23 GB'));
-
-		$connection->expects($this->at(1))
-			->method('__get')
 			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue('myquota'));
 
-		$connection->expects($this->exactly(2))
+		/* Having a quota defined, the ldapQuotaDefault won't be used
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GB'));
+		*/
+
+		$connection->expects($this->exactly(1))
 			->method('__get');
 
 		$access->expects($this->once())
@@ -244,13 +246,13 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue('25 GB'));
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
-			->will($this->returnValue('myquota'));
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('25 GB'));
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
@@ -289,15 +291,17 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
-
-		$connection->expects($this->at(1))
-			->method('__get')
 			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue('myquota'));
 
-		$connection->expects($this->exactly(2))
+		/* Having a quota set this won't be used
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue(''));
+		*/
+
+		$connection->expects($this->exactly(1))
 			->method('__get');
 
 		$access->expects($this->once())
@@ -334,13 +338,13 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
-			->will($this->returnValue('myquota'));
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue(''));
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
@@ -372,12 +376,12 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->at(0))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
+			->with($this->equalTo('ldapQuotaAttribute'))
 			->will($this->returnValue(''));
 
 		$connection->expects($this->at(1))
 			->method('__get')
-			->with($this->equalTo('ldapQuotaAttribute'))
+			->with($this->equalTo('ldapQuotaDefault'))
 			->will($this->returnValue(''));
 
 		$connection->expects($this->exactly(2))
@@ -407,15 +411,9 @@ class UserTest extends \Test\TestCase {
 
 		$readQuota = '19 GB';
 
-		$connection->expects($this->at(0))
+		$connection->expects($this->never())
 			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(''));
-
-		$connection->expects($this->once(1))
-			->method('__get')
-			->with($this->equalTo('ldapQuotaDefault'))
-			->will($this->returnValue(null));
+			->with($this->equalTo('ldapQuotaDefault'));
 
 		$access->expects($this->never())
 			->method('readAttribute');

--- a/tests/User/UserTest.php
+++ b/tests/User/UserTest.php
@@ -355,6 +355,16 @@ class UserTest extends \Test\TestCase {
 				$this->equalTo('myquota'))
 			->will($this->returnValue(false));
 
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
 		$config->expects($this->never())
 			->method('setUserValue');
 
@@ -386,6 +396,17 @@ class UserTest extends \Test\TestCase {
 
 		$connection->expects($this->exactly(2))
 			->method('__get');
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
 
 		$access->expects($this->never())
 			->method('readAttribute');
@@ -435,6 +456,195 @@ class UserTest extends \Test\TestCase {
 			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
 
 		$user->updateQuota($readQuota);
+	}
+
+	/**
+	 * Unparseable quota will fallback to use the LDAP default
+	 */
+	public function testUpdateWrongQuotaAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GB'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('42 GBwos')));
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('23 GB');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * No user quota and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongDefaultQuotaProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(false));
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * Wrong user quota and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongQuotaAndDefaultAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('23 flush')));
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	/**
+	 * No quota attribute set and wrong default will set 'default' as quota
+	 */
+	public function testUpdateWrongDefaultQuotaNotProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue(''));
+
+		$connection->expects($this->at(1))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaDefault'))
+			->will($this->returnValue('23 GBwowowo'));
+
+		$connection->expects($this->exactly(2))
+			->method('__get');
+
+		$access->expects($this->never())
+			->method('readAttribute');
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
 	}
 
 	//the testUpdateAvatar series also implicitely tests getAvatarImage

--- a/tests/User/UserTest.php
+++ b/tests/User/UserTest.php
@@ -237,6 +237,86 @@ class UserTest extends \Test\TestCase {
 		$user->updateQuota();
 	}
 
+	public function testUpdateQuotaToDefaultAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->exactly(1))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('default')));
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('default');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
+	public function testUpdateQuotaToNoneAllProvided() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		list($access, $connection) =
+			$this->getAdvancedMocks($config, $filesys, $log, $avaMgr, $dbc);
+
+		$connection->expects($this->at(0))
+			->method('__get')
+			->with($this->equalTo('ldapQuotaAttribute'))
+			->will($this->returnValue('myquota'));
+
+		$connection->expects($this->exactly(1))
+			->method('__get');
+
+		$access->expects($this->once())
+			->method('readAttribute')
+			->with($this->equalTo('uid=alice,dc=foo,dc=bar'),
+				$this->equalTo('myquota'))
+			->will($this->returnValue(array('none')));
+
+		$user = $this->createMock('\OCP\IUser');
+		$user->expects($this->once())
+			->method('setQuota')
+			->with('none');
+
+		$userMgr->expects($this->once())
+			->method('get')
+			->with('alice')
+			->will($this->returnValue($user));
+
+		$uid = 'alice';
+		$dn  = 'uid=alice,dc=foo,dc=bar';
+
+		$user = new User(
+			$uid, $dn, $access, $config, $filesys, $image, $log, $avaMgr, $userMgr);
+
+		$user->updateQuota();
+	}
+
 	public function testUpdateQuotaDefaultProvided() {
 		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
 			$this->getTestInstances();


### PR DESCRIPTION
Expected behaviour with these changes:
* If both LDAP quota field and default LDAP quota are set:
    * if the user has a value for the LDAP quota attribute, try to use that value as quota
    * if the user doesn't have a value for the LDAP quota attribute or the value can't be parsed correctly, use the default LDAP quota.
    * if the user doesn't have a value for the LDAP quota attribute or the value can't be parsed correctly, and the default LDAP quota can't be parsed correctly, use the ownCloud's default quota.
* If the LDAP quota field is empty and the default LDAP quota is set:
    * go through the above case and consider the user doesn't have the LDAP quota attribute set.
* If the LDAP quota field isn't empty and the LDAP default quota isn't set:
    * if the user has a value for the attribute, try to use that value as quota.
    * if the user doesn't have a value for the attribute **do not change anything**. This usually means that the ownCloud's default quota will be used. If the user's quota has a previous value, that value will be kept
* If neither the LDAP quota field nor the default LDAP quota is set, keep the current quota.

Additional changes:
* Explictly support "default" and "none" as valid values for the LDAP quota, both as default LDAP quota and as value for the attribute (not sure if it was supported before).
* Added new logs to troubleshoot weird quota strings.

Notes:
* Even if the user "uses" the default LDAP quota, that value **will be effectively set** as quota. If the admin remove the default LDAP quota at a later time, the previous default LDAP quota might still be used by other users.
* Changes in the quota aren't applied uniformly. They depend on when the user data is fetched from the LDAP. If you set a default LDAP quota value "A", then you change it to "B" and finally change it again to "C", quota values for different users might be "A", "B" or "C" at some point. It's expected that when you access to the user data (or the user logs in) the quota is applied correctly. However, keep in mind that there are some cases (check above) where the quota isn't changed, which will result in unexpected values for the quota.

@PVince81 @DeepDiver1975 to review
@owncloud/qa to verify and check the behaviour
@settermjd in case there is docs to be updated / improved due to this change
