### PR TITLE
Fix user import duplicated mails

### DIFF
--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -448,7 +448,12 @@ class User {
 			if (!is_null($user)) {
 				$currentEmail = strval($user->getEMailAddress());
 				if ($currentEmail !== $email) {
-					$user->setEMailAddress($email);
+					try {
+						$user->setEMailAddress($email);
+					} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $ex) {
+						\OCP\Util::writeLog('user_ldap', 'can\'t set email [' . $email .'] for user ['. $this->uid .']. Trying to set as empty email', \OCP\Util::WARN);
+						$user->setEMailAddress(null);
+					}
 				}
 			}
 		}

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -452,7 +452,11 @@ class User {
 						$user->setEMailAddress($email);
 					} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $ex) {
 						\OCP\Util::writeLog('user_ldap', 'can\'t set email [' . $email .'] for user ['. $this->uid .']. Trying to set as empty email', \OCP\Util::WARN);
-						$user->setEMailAddress(null);
+						try {
+							$user->setEMailAddress(null);
+						} catch (\Doctrine\DBAL\Exception\UniqueConstraintViolationException $ex) {
+							\OCP\Util::writeLog('user_ldap', 'can\'t set email [' . $email .'] nor making it empty for user ['. $this->uid .']', \OCP\Util::ERROR);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Log a message and try to set the email as null if it's duplicated, logging again if it isn't possible. Duplicated emails will be ignored.