### PR TITLE
Import search attributes into core account table for faster searching

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -9,7 +9,7 @@ A user logs into ownCloud with their LDAP or AD credentials, and is granted acce
 	</description>
 	<licence>AGPL</licence>
 	<author>Dominik Schmidt and Arthur Schiwon</author>
-	<version>0.9.0</version>
+	<version>0.9.1</version>
 	<types>
 		<authentication/>
 	</types>

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -155,6 +155,12 @@ class Manager {
 			}
 		}
 
+		// Do we have custom search attributes for this configuration?
+		$search = $this->access->getConnection()->ldapAttributesForUserSearch;
+		if(!is_null($search)) {
+			$attributes = array_merge($attributes, $search);
+		}
+
 		$homeRule = $this->access->getConnection()->homeFolderNamingRule;
 		if(strpos($homeRule, 'attr:') === 0) {
 			$attributes[] = substr($homeRule, strlen('attr:'));

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -157,7 +157,7 @@ class Manager {
 
 		// Do we have custom search attributes for this configuration?
 		$search = $this->access->getConnection()->ldapAttributesForUserSearch;
-		if(!is_null($search)) {
+		if(!empty($search)) {
 			$attributes = array_merge($attributes, $search);
 		}
 

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -444,20 +444,13 @@ class User {
 		}
 		$user = $this->userManager->get($this->uid);
 		if (!is_null($user)) {
-			$rawAttributes = $this->connection->ldapAttributesForUserSearch;
-			$attributes = empty($rawAttributes) ? [] : $rawAttributes;
 			// Get from LDAP if we don't have it already
-			$searchTerms = [];
 			if(is_null($ldapEntry)) {
-				foreach($attributes as $attr) {
-					foreach ($this->access->readAttribute($this->dn, strtolower($attr)) as $value) {
-						$value = trim($value);
-						if (!empty($value)) {
-							$searchTerms[] = strtolower($value);
-						}
-					}
-				}
+				$searchTerms = $this->getSearchTerms();
 			} else {
+				$searchTerms = [];
+				$rawAttributes = $this->connection->ldapAttributesForUserSearch;
+				$attributes = empty($rawAttributes) ? [] : $rawAttributes;
 				foreach($attributes as $attr) {
 					$lowerAttr = strtolower($attr);
 					if(isset($ldapEntry[$lowerAttr])) {
@@ -469,7 +462,6 @@ class User {
 						}
 					}
 				}
-				unset($attr);
 			}
 
 			// If we have a value, which is different to the current, then let's update the accounts table
@@ -477,6 +469,25 @@ class User {
 				$user->setSearchTerms($searchTerms);
 			}
 		}
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getSearchTerms() {
+		$rawAttributes = $this->connection->ldapAttributesForUserSearch;
+		$attributes = empty($rawAttributes) ? [] : $rawAttributes;
+		// Get from LDAP if we don't have it already
+		$searchTerms = [];
+		foreach($attributes as $attr) {
+			foreach ($this->access->readAttribute($this->dn, strtolower($attr)) as $value) {
+				$value = trim($value);
+				if (!empty($value)) {
+					$searchTerms[] = strtolower($value);
+				}
+			}
+		}
+		return $searchTerms;
 	}
 
 	/**

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -444,7 +444,7 @@ class User {
 		}
 		$user = $this->userManager->get($this->uid);
 		if (!is_null($user)) {
-			$attributes = is_null($this->connection->ldapAttributesForUserSearch) ? [] : $this->connection->ldapAttributesForUserSearch;
+			$attributes = empty($this->connection->ldapAttributesForUserSearch) ? [] : $this->connection->ldapAttributesForUserSearch;
 			// Get from LDAP if we don't have it already
 			$searchTerms = [];
 			if(is_null($ldapEntry)) {

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -200,14 +200,17 @@ class User {
 		}
 		unset($attr);
 
+		// search attribbutes
 		$searchAttributes = '';
-		$attributes = strtolower($this->connection->ldapAttributesForUserSearch);
+		$attributes = $this->connection->ldapAttributesForUserSearch;
 		foreach($attributes as $attr) {
-			if(isset($ldapEntry[$attr])) {
-				$searchAttributes .= strval($ldapEntry[$attr][0]) . ' ';
+			if(isset($ldapEntry[strtolower($attr)])) {
+				$searchAttributes .= strval($ldapEntry[strtolower($attr)][0]) . ' ';
 			}
 		}
-		$this->updateSearchAttributes(null);
+		if(!empty($searchAttributes)) {
+			$this->updateSearchAttributes($searchAttributes);
+		}
 
 		unset($attr);
 
@@ -451,7 +454,6 @@ class User {
 		if($this->wasRefreshed('searchAttributes')) {
 			return;
 		}
-
 		// Get from LDAP if we don't have it already
 		if(is_null($valueFromLDAP)) {
 			$valueFromLDAP = '';
@@ -472,8 +474,7 @@ class User {
 		if ($valueFromLDAP !== '') {
 			$user = $this->userManager->get($this->uid);
 			if (!is_null($user)) {
-				$currentSearchAttributes = strval($user->getSearchAttributes());
-				if ($currentSearchAttributes !== $valueFromLDAP) {
+				if ($user->getSearchAttributes() !== $valueFromLDAP) {
 					$user->setSearchAttributes($valueFromLDAP);
 				}
 			}

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -203,16 +203,17 @@ class User {
 		// search attribbutes
 		$searchAttributes = '';
 		$attributes = $this->connection->ldapAttributesForUserSearch;
-		foreach($attributes as $attr) {
-			if(isset($ldapEntry[strtolower($attr)])) {
-				$searchAttributes .= strval($ldapEntry[strtolower($attr)][0]) . ' ';
+		if(!empty($attributes)) {
+			foreach($attributes as $attr) {
+				if(isset($ldapEntry[strtolower($attr)])) {
+					$searchAttributes .= strval($ldapEntry[strtolower($attr)][0]) . ' ';
+				}
 			}
+			if(!empty($searchAttributes)) {
+				$this->updateSearchAttributes($searchAttributes);
+			}
+			unset($attr);
 		}
-		if(!empty($searchAttributes)) {
-			$this->updateSearchAttributes($searchAttributes);
-		}
-
-		unset($attr);
 
 		//homePath
 		if(strpos($this->connection->homeFolderNamingRule, 'attr:') === 0) {

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -444,7 +444,8 @@ class User {
 		}
 		$user = $this->userManager->get($this->uid);
 		if (!is_null($user)) {
-			$attributes = empty($this->connection->ldapAttributesForUserSearch) ? [] : $this->connection->ldapAttributesForUserSearch;
+			$rawAttributes = $this->connection->ldapAttributesForUserSearch;
+			$attributes = empty($rawAttributes) ? [] : $rawAttributes;
 			// Get from LDAP if we don't have it already
 			$searchTerms = [];
 			if(is_null($ldapEntry)) {

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -200,7 +200,7 @@ class User {
 		}
 		unset($attr);
 
-		// search attribbutes
+		// search attributes
 		$searchAttributes = '';
 		$attributes = $this->connection->ldapAttributesForUserSearch;
 		if(!empty($attributes)) {
@@ -458,15 +458,14 @@ class User {
 		// Get from LDAP if we don't have it already
 		if(is_null($valueFromLDAP)) {
 			$valueFromLDAP = '';
-			$attributes = $this->connection->ldapAttributesForUserSearch;
-
+			$attributes = is_null($this->connection->ldapAttributesForUserSearch) ? [] : $this->connection->ldapAttributesForUserSearch;
 			foreach($attributes as $attr) {
 				$attrVal = $this->access->readAttribute($this->dn, strtolower($attr));
 				if(is_array($attrVal) && (count($attrVal) > 0)) {
 					$attrVal = strval($attrVal[0]);
 				}
 				if($attrVal != '') {
-					$valueFromLDAP .= $attrVal . '';
+					$valueFromLDAP .= $attrVal . ' ';
 				}
 			}
 		}
@@ -476,7 +475,7 @@ class User {
 			$user = $this->userManager->get($this->uid);
 			if (!is_null($user)) {
 				if ($user->getSearchAttributes() !== $valueFromLDAP) {
-					$user->setSearchAttributes($valueFromLDAP);
+					$user->setSearchAttributes(trim($valueFromLDAP));
 				}
 			}
 		}

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -36,8 +36,10 @@ namespace OCA\User_LDAP;
 use OC\User\NoUserException;
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
+use OCP\IUserBackend;
+use OCP\UserInterface;
 
-class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserInterface {
+class User_LDAP extends BackendUtility implements IUserBackend, UserInterface {
 
 	/** @var \OCP\IConfig */
 	protected $ocConfig;
@@ -420,6 +422,15 @@ class User_LDAP extends BackendUtility implements \OCP\IUserBackend, \OCP\UserIn
 	 */
 	public function getBackendName(){
 		return 'LDAP';
+	}
+
+	/**
+	 * @param $uid
+	 * @return string[]
+	 */
+	public function getSearchTerms($uid) {
+		$user = $this->access->userManager->get($uid);
+		return $user->getSearchTerms();
 	}
 
 }

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -29,8 +29,11 @@ namespace OCA\User_LDAP;
 
 use OCA\User_LDAP\User\User;
 use OCP\IConfig;
+use OCP\IUserBackend;
+use OCP\User\IProvidesExtendedSearchBackend;
+use OCP\UserInterface;
 
-class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface {
+class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvidesExtendedSearchBackend {
 	private $backends = array();
 	private $refBackend = null;
 
@@ -47,6 +50,14 @@ class User_Proxy extends Proxy implements \OCP\IUserBackend, \OCP\UserInterface 
 				$this->refBackend = &$this->backends[$configPrefix];
 			}
 		}
+	}
+
+	/**
+	 * @param string $uid
+	 * @return string[]
+	 */
+	public function getSearchTerms($uid) {
+		return $this->handleRequest($uid, 'getSearchTerms', array($uid));
 	}
 
 	/**

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -57,7 +57,8 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvides
 	 * @return string[]
 	 */
 	public function getSearchTerms($uid) {
-		return $this->handleRequest($uid, 'getSearchTerms', array($uid));
+		$terms =  $this->handleRequest($uid, 'getSearchTerms', array($uid));
+		return is_array($terms) ? $terms : [];
 	}
 
 	/**

--- a/tests/User/ManagerTest.php
+++ b/tests/User/ManagerTest.php
@@ -242,6 +242,26 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertTrue(in_array('thumbnailphoto', $attributes));
 	}
 
+	public function testGetAttributesWithCustomSearch() {
+		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
+			$this->getTestInstances();
+
+		$manager = new Manager($config, $filesys, $log, $avaMgr, $image, $dbc, $userMgr);
+		$manager->setLdapAccess($access);
+
+		$connection = $access->getConnection();
+		$connection->setConfiguration(array('ldapEmailAttribute' => 'mail'));
+		$connection->setConfiguration(array('ldapAttributesForUserSearch' => 'uidNumber'));
+
+		$attributes = $manager->getAttributes();
+
+		$this->assertTrue(in_array('uidNumber', $attributes));
+		$this->assertTrue(in_array('dn', $attributes));
+		$this->assertTrue(in_array($access->getConnection()->ldapEmailAttribute, $attributes));
+		$this->assertTrue(in_array('jpegphoto', $attributes));
+		$this->assertTrue(in_array('thumbnailphoto', $attributes));
+	}
+
 	public function testGetAttributesMinimal() {
 		list($access, $config, $filesys, $image, $log, $avaMgr, $dbc, $userMgr) =
 			$this->getTestInstances();


### PR DESCRIPTION
Retrieves search attributes from LDAP based on the config and stores them alongside the user in the accounts table using the new search_attributes column.

Requires https://github.com/owncloud/core/issues/27850

@butonic @cdamken 