### PR TITLE
Always set a proper prefix on CLI

### DIFF
--- a/lib/Command/CreateEmptyConfig.php
+++ b/lib/Command/CreateEmptyConfig.php
@@ -60,11 +60,6 @@ class CreateEmptyConfig extends Command {
 	protected function getNewConfigurationPrefix() {
 		$serverConnections = $this->helper->getServerConfigurationPrefixes();
 
-		// first connection uses no prefix
-		if(sizeof($serverConnections) == 0) {
-			return '';
-		}
-
 		sort($serverConnections);
 		$lastKey = array_pop($serverConnections);
 		$lastNumber = intval(str_replace('s', '', $lastKey));


### PR DESCRIPTION
I had to remove the clause to being able to always set values via the
CLI. With this condition you can not configure the first group on the
CLI, without that condition you always get `s01` as a first prefix and
you are able to configure it on the CLI

Signed-off-by: Thomas Boerger <tboerger@owncloud.com>