### PR TITLE
remove unneeded account updates

### DIFF
--- a/lib/Access.php
+++ b/lib/Access.php
@@ -804,38 +804,7 @@ class Access extends LDAPUtility implements IUserTools {
 	 */
 	public function fetchListOfUsers($filter, $attr, $limit = null, $offset = null) {
 		$ldapRecords = $this->searchUsers($filter, $attr, $limit, $offset);
-		$this->batchApplyUserAttributes($ldapRecords);
 		return $this->fetchList($ldapRecords, (count($attr) > 1));
-	}
-
-	/**
-	 * provided with an array of LDAP user records the method will fetch the
-	 * user object and requests it to process the freshly fetched attributes and
-	 * and their values
-	 * @param array $ldapRecords
-	 */
-	public function batchApplyUserAttributes(array $ldapRecords){
-		$displayNameAttribute = strtolower($this->connection->ldapUserDisplayName);
-		foreach($ldapRecords as $userRecord) {
-			if(!isset($userRecord[$displayNameAttribute])) {
-				// displayName is obligatory
-				continue;
-			}
-			$ocName  = $this->dn2ocname($userRecord['dn'][0]);
-			if($ocName === false) {
-				continue;
-			}
-			$this->cacheUserExists($ocName);
-			$user = $this->userManager->get($ocName);
-			if ($user !== null) {
-				$user->processAttributes($userRecord);
-			} else {
-				\OC::$server->getLogger()->debug(
-					"The ldap user manager returned null for $ocName",
-					['app'=>'user_ldap']
-				);
-			}
-		}
 	}
 
 	/**

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -258,9 +258,6 @@ class User_LDAP extends BackendUtility implements IUserBackend, UserInterface {
 
 		$result = $this->userExistsOnLDAP($user);
 		$this->access->connection->writeToCache('userExists'.$uid, $result);
-		if($result === true) {
-			$user->update();
-		}
 		return $result;
 	}
 

--- a/tests/AccessTest.php
+++ b/tests/AccessTest.php
@@ -237,53 +237,6 @@ class AccessTest extends \Test\TestCase {
 		$access->cacheUserHome('foobar', '/foobars/path');
 	}
 
-	public function testBatchApplyUserAttributes() {
-		list($lw, $con, $um) = $this->getConnectorAndLdapMock();
-		$access = new Access($con, $lw, $um);
-		$mapperMock = $this->getMockBuilder('\OCA\User_LDAP\Mapping\UserMapping')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$mapperMock->expects($this->any())
-			->method('getNameByDN')
-			->will($this->returnValue('a_username'));
-
-		$userMock = $this->getMockBuilder('\OCA\User_LDAP\User\User')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$access->connection->expects($this->any())
-			->method('__get')
-			->will($this->returnValue('displayName'));
-
-		$access->setUserMapper($mapperMock);
-
-		$displayNameAttribute = strtolower($access->connection->ldapUserDisplayName);
-		$data = array(
-			array(
-				'dn' => 'foobar',
-				$displayNameAttribute => 'barfoo'
-			),
-			array(
-				'dn' => 'foo',
-				$displayNameAttribute => 'bar'
-			),
-			array(
-				'dn' => 'raboof',
-				$displayNameAttribute => 'oofrab'
-			)
-		);
-
-		$userMock->expects($this->exactly(count($data)))
-			->method('processAttributes');
-
-		$um->expects($this->exactly(count($data)))
-			->method('get')
-			->will($this->returnValue($userMock));
-
-		$access->batchApplyUserAttributes($data);
-	}
-
 	public function dNAttributeProvider() {
 		// corresponds to Access::resemblesDN()
 		return array(


### PR DESCRIPTION
While working on #28212 I was profiling the performance for user:sync and this actually made a measurable difference. The user:sync command already has explicit update logic. The update logic in checkPassword remains.