### PR TITLE
Add missing spaces to log message

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -430,8 +430,8 @@ class Connection extends LDAPUtility {
 			|| ($agent !== '' && $pwd === '')
 		) {
 			\OCP\Util::writeLog('user_ldap',
-								$errorStr.'either no password is given for the'.
-								'user agent or a password is given, but not an'.
+								$errorStr.'either no password is given for the '.
+								'user agent or a password is given, but not an '.
 								'LDAP agent.',
 				\OCP\Util::WARN);
 			$configurationOK = false;


### PR DESCRIPTION
The current log is something like:

``Configuration Error (prefix ): either no password is given for theuser agent or a password is given, but not anLDAP agent.``

Afterwards it has the correct spaces like:

``Configuration Error (prefix ): either no password is given for the user agent or a password is given, but not an LDAP agent.``