### PR TITLE
Only use IndexIgnore if mod_autoindex.c is enabled/loaded

### DIFF
--- a/tests/.htaccess
+++ b/tests/.htaccess
@@ -11,4 +11,6 @@ Satisfy All
 </ifModule>
 
 # section for Apache 2.2 and 2.4
+<ifModule mod_autoindex.c>
 IndexIgnore *
+</ifModule>


### PR DESCRIPTION
Same as https://github.com/owncloud/core/issues/28343

Ref: https://github.com/owncloud/core/issues/28307