### PR TITLE
Fix handle request to correctly call backend when cache is empty

### DIFF
--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -118,7 +118,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvides
 				return $result;
 			}
 		}
-		return false;
+		return $passOnWhen;
 	}
 
 	/**


### PR DESCRIPTION
This allows the handleRequest method to call the userBackend, even when the caches return empty values. Without this, callOnLastSeenOn() was returning false, which was compared to $passOnWhen - whereas, it should pass through $passOnWhen for the comparison.

This fixes an issue where the search terms are not correctly saved during user sync