### PR TITLE
user_ldap: Makes the time between needsRefresh configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,11 @@
     * This option affects all LDAP connections. It isn't possible to enable this option for a specific connection.
     * This option could have a performance impact on big LDAP installations. Check your LDAP provider how to enable indexes for medial searches if they're supported but not active.
     * The option will work regardless of whether the LDAP server has an index for this. Small LDAP installations could have an acceptable performance with this option active even if the LDAP doesn't have that index active.
+
+#### Additional configuration options that can be modified via occ configurations 
+
+The user_ldap app refreshs will check for updated attributes at every user login. Attributes like mail oder quota are retrieved from the ldap server. To save ressources on the ldap server, there is a minimum time between two updates for every user. Without modification, the update intervall is not more often then 86400 seconds (1 day). This can be modifed by setting the app config 'updateAttributesInterval' to any number you like. Setting this value to 0 will update on very login request which can be quiet often and stress your ldap server.
+Attributes are unlikely to change very often, but waiting a day for a new quota is maybe a little bit long.
+
+To allow modify the minimum time between checks to one hour (3600 seconds) you can do this via occ:
+```occ config:app:set user_ldap updateAttributesInterval  --value=3600 --type=integer```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 
 #### Additional configuration options that can be modified via occ configurations 
 
-The user_ldap app refreshs will check for updated attributes at every user login. Attributes like mail oder quota are retrieved from the ldap server. To save ressources on the ldap server, there is a minimum time between two updates for every user. Without modification, the update intervall is not more often then 86400 seconds (1 day). This can be modifed by setting the app config 'updateAttributesInterval' to any number you like. Setting this value to 0 will update on very login request which can be quiet often and stress your ldap server.
+The user_ldap app  will check for updated attributes at every user login. Attributes like mail oder quota are retrieved from the ldap server. To save ressources on the ldap server, there is a minimum time between two updates for every user. Without modification, the update intervall is not more often then 86400 seconds (1 day). This can be modifed by setting the app config 'updateAttributesInterval' to any number you like. Setting this value to 0 will update on very login request which can be quiet often and stress your ldap server.
 Attributes are unlikely to change very often, but waiting a day for a new quota is maybe a little bit long.
 
-To allow modify the minimum time between checks to one hour (3600 seconds) you can do this via occ:
-```occ config:app:set user_ldap updateAttributesInterval  --value=3600 --type=integer```
+To allow modificatons of minimum time between checks to one hour (3600 seconds) you can do this via occ:
+```occ config:app:set user_ldap updateAttributesInterval  --value=3600 ```

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -357,8 +357,7 @@ class User {
 		$lastChecked = $this->config->getUserValue($this->uid, 'user_ldap',
 			self::USER_PREFKEY_LASTREFRESH, 0);
 
-		//TODO make interval configurable
-		if((time() - intval($lastChecked)) < 86400 ) {
+		if((time() - intval($lastChecked)) < $this->config->getAppValue('user_ldap', 'updateAttribuesInterval', 86400) ) {
 			return false;
 		}
 		return  true;

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -357,7 +357,7 @@ class User {
 		$lastChecked = $this->config->getUserValue($this->uid, 'user_ldap',
 			self::USER_PREFKEY_LASTREFRESH, 0);
 
-		if((time() - intval($lastChecked)) < $this->config->getAppValue('user_ldap', 'updateAttribuesInterval', 86400) ) {
+		if((time() - intval($lastChecked)) < $this->config->getAppValue('user_ldap', 'updateAttributesInterval', 86400) ) {
 			return false;
 		}
 		return  true;

--- a/lib/User/User.php
+++ b/lib/User/User.php
@@ -357,7 +357,7 @@ class User {
 		$lastChecked = $this->config->getUserValue($this->uid, 'user_ldap',
 			self::USER_PREFKEY_LASTREFRESH, 0);
 
-		if((time() - intval($lastChecked)) < $this->config->getAppValue('user_ldap', 'updateAttributesInterval', 86400) ) {
+		if((time() - intval($lastChecked)) < intval($this->config->getAppValue('user_ldap', 'updateAttributesInterval', 86400)) ) {
 			return false;
 		}
 		return  true;

--- a/tests/User/UserTest.php
+++ b/tests/User/UserTest.php
@@ -1177,8 +1177,15 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->equalTo(0))
-			->will($this->returnValue(time()));
-
+				->will($this->returnValue(time() - 10));
+		
+		$config->expects($this->once())
+			->method('getAppValue')
+			->with($this->equalTo('user_ldap'),
+				$this->equalTo('updateAttributesInterval'),
+				$this->anything())
+			->will($this->returnValue(1800);
+			       
 		$config->expects($this->exactly(2))
 			->method('getUserValue');
 

--- a/tests/User/UserTest.php
+++ b/tests/User/UserTest.php
@@ -1177,7 +1177,7 @@ class UserTest extends \Test\TestCase {
 			->with($this->equalTo('alice'), $this->equalTo('user_ldap'),
 				$this->equalTo(User::USER_PREFKEY_LASTREFRESH),
 				$this->equalTo(0))
-				->will($this->returnValue(time() - 10));
+			->will($this->returnValue(time() - 10));
 		
 		$config->expects($this->once())
 			->method('getAppValue')


### PR DESCRIPTION


**Description**

Makes the time between needsRefresh configurable via app config option updateAttribuesInterval.
Default is still 86400 secons which is one day.

**Motivation and Context**

Modify the interval without changing the sourcecode to make the interval persistent when updating


**Types of changes**

- ~~Bug fix (non-breaking change which fixes an issue)~~
- [x] New feature (non-breaking change which adds functionality)
- ~~Breaking change (fix or feature that would cause existing functionality to change)~~

**Checklist:**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x]  updated the documentation accordingly.  ->(https://github.com/owncloud/documentation/issues/3278#issuecomment-321467584)
- [x]  I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.