### PR TITLE
Log LDAP calls as events for diagnostics (fix_user_access base)

### DIFF
--- a/lib/LDAP.php
+++ b/lib/LDAP.php
@@ -245,6 +245,22 @@ class LDAP implements ILDAPWrapper {
 		return is_resource($resource);
 	}
 
+	private function formatLdapCallArguments($func, $arguments) {
+		$argumentsLog = implode(",",
+			array_map(
+				function($argument) {
+					if (is_string($argument) || is_bool($argument) || is_numeric($argument)) {
+						return strval($argument);
+					}
+					return gettype($argument);
+				},
+				$arguments
+			)
+		);
+
+		return $func."(".$argumentsLog.")";
+	}
+
 	/**
 	 * @return mixed
 	 */
@@ -252,11 +268,19 @@ class LDAP implements ILDAPWrapper {
 		$arguments = func_get_args();
 		$func = 'ldap_' . array_shift($arguments);
 		if(function_exists($func)) {
+			// Start logging event
+			$eventId = uniqid($func);
+			\OC::$server->getEventLogger()->start($eventId, $this->formatLdapCallArguments($func, $arguments));
+
+			// Execute call
 			$this->preFunctionCall($func, $arguments);
 			$result = call_user_func_array($func, $arguments);
 			if ($result === FALSE) {
 				$this->postFunctionCall();
 			}
+
+			// Finish logging event
+			\OC::$server->getEventLogger()->end($eventId);
 			return $result;
 		}
 		return null;


### PR DESCRIPTION
Now diagnostic will additionally log not only:

{"type":"SUMMARY","reqId":"2SbkuVM7SIi1AYznLWOr","time":"2017-09-03T18:25:20+00:00","remoteAddr":"::1","user":"admin","method":"GET","url":"\/octest\/index.php\/settings\/users","diagnostics":{"totalSQLQueries":7074,"totalSQLDurationmsec":101634.19699669,"totalSQLParams":12178,"totalEvents":**11044**,"totalEventsDurationmsec":**309342409.3241**7}}

But also:

{"type":"EVENT","reqId":"h4omRwYvlrurorofXIys","diagnostics":{"eventDescription":"**ldap_read(resource,cn=army994,ou=armies,dc=owncloud,dc=com,objectClass=*,array)**","eventDurationmsec":**416.74113273621**,"eventTimestamp":1504463311.8281}}

@butonic @felixboehm 