### PR TITLE
apps/user_ldap: fix installation with utf8mb4 as DB charset

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -16,7 +16,7 @@
     <name>ldap_dn</name>
     <type>text</type>
     <notnull>true</notnull>
-	<length>255</length>
+	<length>191</length>
 	<default></default>
    </field>
 
@@ -24,7 +24,7 @@
     <name>owncloud_name</name>
     <type>text</type>
     <notnull>true</notnull>
-    <length>255</length>
+    <length>191</length>
 	<default></default>
    </field>
 
@@ -68,7 +68,7 @@
     <name>ldap_dn</name>
     <type>text</type>
     <notnull>true</notnull>
-    <length>255</length>
+    <length>191</length>
     <default></default>
    </field>
 
@@ -76,7 +76,7 @@
     <name>owncloud_name</name>
     <type>text</type>
     <notnull>true</notnull>
-    <length>255</length>
+    <length>191</length>
     <default></default>
    </field>
 
@@ -121,7 +121,7 @@
     <name>owncloudname</name>
     <type>text</type>
     <notnull>true</notnull>
-    <length>255</length>
+    <length>191</length>
     <default></default>
    </field>
 


### PR DESCRIPTION
MySQL/MariaDB's key length is limited to 764 bytes, or 191 4-byte characters.

When the characterset of the nextcloud DB is set to utf8mb4, enabling user_ldap
yields

[Doctrine\DBAL\Exception\DriverException]
  An exception occurred while executing 'CREATE TABLE `oc_ldap_user_mapping` (`ldap_dn` VARCHAR(255) DEFAULT '' NOT NULL, `owncloud_name` VARCHAR(255) DEFAULT '' NOT NULL, `directory_uuid` VARCHAR(255) DEFAULT
   '' NOT NULL, UNIQUE INDEX ldap_dn_users (`ldap_dn`), PRIMARY KEY(`owncloud_name`)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin ENGINE = InnoDB ROW_FORMAT = compressed':
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes

  [Doctrine\DBAL\Driver\PDOException]
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes

  [PDOException]
  SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 767 bytes


This patch shortens the length of the affected columns in order for index/PK
definitions to be able to accomodate them.

Fixes #135