### PR TITLE
Do not set false quota on login

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -362,7 +362,9 @@ class Manager {
 	 */
 	public function updateQuota(UserEntry $userEntry, IUser $targetUser) {
 		$newQuota = $userEntry->getQuota();
-		$targetUser->setQuota($newQuota);
+		if ($newQuota !== false) { // only update if we get a value
+			$targetUser->setQuota($newQuota);
+		}
 	}
 
 	/**

--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -199,7 +199,7 @@ class UserEntry {
 	 * values are 'none' (unlimited), 'default' (the ownCloud's default quota), '1234' (quota in
 	 * bytes), '1234 MB' (quota in MB - check the \OC_Helper::computerFileSize method for more info)
 	 *
-	 * @return string quota
+	 * @return string|false quota
 	 * TODO throw Exception for invalid values after https://github.com/owncloud/core/pull/28805 has been merged
 	 */
 	public function getQuota() {


### PR DESCRIPTION
When no quota attribute has been configured and no quota default for ldap users, logging in a user will use `false` to set the quota, which becomes ` B`, an invalid quota oc treats as 0b. any existing quota that may have been set by the admin gets overwritten.

This pr only updates the quota of an account if it has been confugired and returns a non `false` value.