### PR TITLE
fix typo in DoesNotExsitOnLDAPException

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -28,7 +28,7 @@ namespace OCA\User_LDAP\User;
 use OC\Cache\CappedMemoryCache;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
-use OCA\User_LDAP\Exceptions\DoesNotExsitOnLDAPException;
+use OCA\User_LDAP\Exceptions\DoesNotExistOnLDAPException;
 use OCA\User_LDAP\FilesystemHelper;
 use OCA\User_LDAP\Mapping\AbstractMapping;
 use OCA\User_LDAP\Mapping\UserMapping;
@@ -184,7 +184,7 @@ class Manager {
 	 * Gets an UserEntry from the LDAP server from a distinguished name
 	 * @param $dn
 	 * @return UserEntry
-	 * @throws DoesNotExsitOnLDAPException when the dn supplied cannot be found on LDAP
+	 * @throws DoesNotExistOnLDAPException when the dn supplied cannot be found on LDAP
 	 */
 	public function getUserEntryByDn($dn) {
 		$result = $this->access->executeRead(
@@ -194,7 +194,7 @@ class Manager {
 			'objectClass=*',
 			20);
 		if($result === false || $result['count'] === 0) {
-			throw new DoesNotExsitOnLDAPException($dn);
+			throw new DoesNotExistOnLDAPException($dn);
 		}
 		// Try to convert entry into a UserEntry
 		return $this->getFromEntry($result);

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -192,8 +192,9 @@ class Manager {
 			$dn,
 			$this->getAttributes(),
 			'objectClass=*',
-			20);
+			20); // TODO why 20? why is 1 not sufficient?
 		if($result === false || $result['count'] === 0) {
+			// FIXME the ldap error ($result = false) should bubble up ... and not be converted to a DoesNotExistOnLDAPException
 			throw new DoesNotExistOnLDAPException($dn);
 		}
 		// Try to convert entry into a UserEntry

--- a/tests/User/ManagerTest.php
+++ b/tests/User/ManagerTest.php
@@ -330,7 +330,28 @@ class ManagerTest extends \Test\TestCase {
 				'count' => 1, // TODO this mixing of count and dn smells bad
 				'dn' => ['cn=foo,ou=users,dc=foobar,dc=bar'], // all ldap array values are multivalue
 			]));
+		$this->access->expects($this->once())
+			->method('isDNPartOfBase')
+			->will($this->returnValue(true));
+
 		$this->assertInstanceOf(UserEntry::class, $this->manager->getUserEntryByDn('cn=foo,ou=users,dc=foobar,dc=bar'));
+	}
+
+	/**
+	 * @expectedException \OutOfBoundsException
+	 */
+	public function testGetUserEntryByDnNotPartOfBase() {
+		$this->access->expects($this->once())
+			->method('executeRead')
+			->will($this->returnValue([
+				'count' => 1, // TODO this mixing of count and dn smells bad
+				'dn' => ['cn=foo,ou=users,dc=foobar,dc=bar'], // all ldap array values are multivalue
+			]));
+		$this->access->expects($this->once())
+			->method('isDNPartOfBase')
+			->will($this->returnValue(false));
+
+		$this->manager->getUserEntryByDn('cn=foo,ou=users,dc=foobar,dc=bar');
 	}
 
 	/**

--- a/tests/User/ManagerTest.php
+++ b/tests/User/ManagerTest.php
@@ -328,9 +328,9 @@ class ManagerTest extends \Test\TestCase {
 			->method('executeRead')
 			->will($this->returnValue([
 				'count' => 1, // TODO this mixing of count and dn smells bad
-				'dn' => 'dc=foobar,dc=bar',
+				'dn' => ['cn=foo,ou=users,dc=foobar,dc=bar'], // all ldap array values are multivalue
 			]));
-		$this->assertInstanceOf(UserEntry::class, $this->manager->getUserEntryByDn('dc=foobar,dc=bar'));
+		$this->assertInstanceOf(UserEntry::class, $this->manager->getUserEntryByDn('cn=foo,ou=users,dc=foobar,dc=bar'));
 	}
 
 	/**

--- a/tests/User/ManagerTest.php
+++ b/tests/User/ManagerTest.php
@@ -330,6 +330,17 @@ class ManagerTest extends \Test\TestCase {
 				'count' => 1, // TODO this mixing of count and dn smells bad
 				'dn' => ['cn=foo,ou=users,dc=foobar,dc=bar'], // all ldap array values are multivalue
 			]));
+
+		$mapper = $this->createMock(UserMapping::class);
+		$mapper->expects($this->once())
+			->method('getNameByDN')
+			->with($this->equalTo('cn=foo,ou=users,dc=foobar,dc=bar'))
+			->will($this->returnValue('foo'));
+
+		$this->access->expects($this->any())
+			->method('getUserMapper')
+			->will($this->returnValue($mapper));
+
 		$this->access->expects($this->once())
 			->method('isDNPartOfBase')
 			->will($this->returnValue(true));


### PR DESCRIPTION
fixes this
```
✗ sudo php occ user:sync "OCA\User_LDAP\User_Proxy"
If unknown users are found, what do you want to do with their accounts? (removing the account will also remove its data)
  [0] disable
  [1] remove
  [2] ask later
 > 1
Analyse unknown users ...
    2 [-->-------------------------]An unhandled exception has been thrown:
Error: Class 'OCA\User_LDAP\Exceptions\DoesNotExsitOnLDAPException' not found in /mnt/c/Users/jfd/Repositories/oc/core/apps-repos/user_ldap/lib/User/Manager.php:197
Stack trace:
#0 /mnt/c/Users/jfd/Repositories/oc/core/apps-repos/user_ldap/lib/User_LDAP.php(196): OCA\User_LDAP\User\Manager->getUserEntryByDn('uid=zombie295,o...')
#1 [internal function]: OCA\User_LDAP\User_LDAP->userExists('8d9e8286-d23b-1...')
#2 /mnt/c/Users/jfd/Repositories/oc/core/apps-repos/user_ldap/lib/User_Proxy.php(75): call_user_func_array(Array, Array)
#3 /mnt/c/Users/jfd/Repositories/oc/core/apps-repos/user_ldap/lib/Proxy.php(140): OCA\User_LDAP\User_Proxy->walkBackends('8d9e8286-d23b-1...', 'userExists', Array)
#4 /mnt/c/Users/jfd/Repositories/oc/core/apps-repos/user_ldap/lib/User_Proxy.php(168): OCA\User_LDAP\Proxy->handleRequest('8d9e8286-d23b-1...', 'userExists', Array)
#5 /mnt/c/Users/jfd/Repositories/oc/core/lib/private/User/SyncService.php(81): OCA\User_LDAP\User_Proxy->userExists('8d9e8286-d23b-1...')
#6 /mnt/c/Users/jfd/Repositories/oc/core/lib/private/User/AccountMapper.php(233): OC\User\SyncService->OC\User\{closure}(Object(OC\User\Account))
#7 /mnt/c/Users/jfd/Repositories/oc/core/lib/private/User/SyncService.php(86): OC\User\AccountMapper->callForAllUsers(Object(Closure), '', false)
#8 /mnt/c/Users/jfd/Repositories/oc/core/core/Command/User/SyncBackend.php(191): OC\User\SyncService->getNoLongerExistingUsers(Object(Closure))
#9 /mnt/c/Users/jfd/Repositories/oc/core/core/Command/User/SyncBackend.php(126): OC\Core\Command\User\SyncBackend->handleUnknownUsers(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput), Object(OC\User\SyncService), 'remove', Array)
#10 /mnt/c/Users/jfd/Repositories/oc/core/lib/composer/symfony/console/Command/Command.php(264): OC\Core\Command\User\SyncBackend->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#11 /mnt/c/Users/jfd/Repositories/oc/core/lib/composer/symfony/console/Application.php(874): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#12 /mnt/c/Users/jfd/Repositories/oc/core/lib/composer/symfony/console/Application.php(228): Symfony\Component\Console\Application->doRunCommand(Object(OC\Core\Command\User\SyncBackend), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#13 /mnt/c/Users/jfd/Repositories/oc/core/lib/composer/symfony/console/Application.php(130): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#14 /mnt/c/Users/jfd/Repositories/oc/core/lib/private/Console/Application.php(162): Symfony\Component\Console\Application->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#15 /mnt/c/Users/jfd/Repositories/oc/core/console.php(106): OC\Console\Application->run()
#16 /mnt/c/Users/jfd/Repositories/oc/core/occ(11): require_once('/mnt/c/Users/jf...')
#17 {main}%
```