### PR TITLE
fake set displayname support

### DIFF
--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -274,6 +274,7 @@ class User_LDAP implements IUserBackend, UserInterface {
 		return (bool)((Backend::CHECK_PASSWORD
 			| Backend::GET_HOME
 			| Backend::GET_DISPLAYNAME
+			| Backend::SET_DISPLAYNAME // not really, but it is stored in the account table
 			| Backend::PROVIDE_AVATAR
 			| Backend::COUNT_USERS)
 			& $actions);

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -215,6 +215,10 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvides
 		return $this->handleRequest($uid, 'getDisplayName', array($uid));
 	}
 
+	public function setDisplayName($uid, $displayName) {
+		// ignored, function needed to make core store the display name in the account table
+
+	}
 	/**
 	 * checks whether the user is allowed to change his avatar in ownCloud
 	 * @param string $uid the ownCloud user name


### PR DESCRIPTION
core will only uppdate the account if the backend supports setting it. this is a workaround. needs fixing in core. but core should handle the sync update anyway. 