### PR TITLE
Reuse existing LDAP accounts if available

### DIFF
--- a/lib/Access.php
+++ b/lib/Access.php
@@ -608,14 +608,14 @@ class Access implements IUserTools {
 		$this->connection->setConfiguration(['ldapCacheTTL' => 0]);
 		if (($isUser && $this->shouldMapToUsername($intName))
 			|| (!$isUser && $this->shouldMapToGroupname($intName))) {
-			\OC::$server->getLogger()->info("Reusing existing mapping for ownCloud UUID: $intName to LDAP UUID: $uuid", ['app' => 'user_ldap']);
+			\OC::$server->getLogger()->info("Reusing existing mapping for ownCloud identifer: $intName to LDAP UUID: $uuid", ['app' => 'user_ldap']);
 			if ($mapper->map($fdn, $intName, $uuid)) {
 				$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 				return $intName;
 			}
 		}
 		$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
-		\OC::$server->getLogger()->error("Mapping collision for DN $fdn and UUID $uuid. Couldn't map to: $intName", ['app' => 'user_ldap']);
+		\OC::$server->getLogger()->error("Mapping collision for DN $fdn and UUID $uuid. Couldn't map to identifer: $intName", ['app' => 'user_ldap']);
 		//if everything else did not help..
 		return false;
 	}

--- a/lib/Access.php
+++ b/lib/Access.php
@@ -606,10 +606,10 @@ class Access implements IUserTools {
 		// outside of core user management will still cache the user as non-existing.
 		$originalTTL = $this->connection->ldapCacheTTL;
 		$this->connection->setConfiguration(['ldapCacheTTL' => 0]);
-		if(($isUser && $this->shouldMapToUsername($intName))
+		if (($isUser && $this->shouldMapToUsername($intName))
 			|| (!$isUser && !\OC::$server->getGroupManager()->groupExists($intName))) {
 			\OC::$server->getLogger()->info("Reusing existing mapping for ownCloud UUID: $intName to LDAP UUID: $uuid", ['app' => 'user_ldap']);
-			if($mapper->map($fdn, $intName, $uuid)) {
+			if ($mapper->map($fdn, $intName, $uuid)) {
 				$this->connection->setConfiguration(['ldapCacheTTL' => $originalTTL]);
 				return $intName;
 			}
@@ -627,12 +627,12 @@ class Access implements IUserTools {
 	 */
 	public function shouldMapToUsername($username) {
 		$user = \OC::$server->getUserManager()->get($username);
-		if($user === null) {
+		if ($user === null) {
 			\OC::$server->getLogger()->info("No account exists with username: $username so cannot reuse mapping", ['app' => 'user_ldap']);
 			// No account exists with this username, use this mapping
 			return true;
 		}
-		if($user->getBackendClassName() === 'LDAP') {
+		if ($user->getBackendClassName() === 'LDAP' && \OC::$server->getConfig()->getAppValue('user_ldap', 'reuse_accounts', 'no') === 'yes') {
 			// Account with same username exists, and matching backend, we can use this - merge
 			return true;
 		}
@@ -715,7 +715,6 @@ class Access implements IUserTools {
 	public function cacheUserExists($ocName) {
 		$this->connection->writeToCache("userExists$ocName", true);
 	}
-
 
 	/*
 	 * fetches a list of users according to a provided loginName and utilizing

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -362,28 +362,13 @@ class Manager {
 
 		//a new user/group! Add it only if it doesn't conflict with other backend's users or existing groups
 		$intName = \trim($this->access->sanitizeUsername($userEntry->getUserId()));
-		if ($intName !== '' && !\OCP\User::userExists($intName)) {
-			$this->logger->debug(
-				'creating new mapping for {name}, uuid {uuid}, dn {dn}',
-				[
-					'app'  => __METHOD__,
-					'name' => $intName,
-					'uuid' => $uuid,
-					'dn'   => $dn
-				]
-			);
-			if ($mapper->map($dn, $intName, $uuid)) {
+		if($intName !== '' && $this->access->shouldMapToUsername($intName)) {
+			if($mapper->map($dn, $intName, $uuid)) {
 				return $intName;
 			}
 		}
 
-		// FIXME move to a better place, naming related. eg DistinguishedNameUtils
-		$altName = $this->access->createAltInternalOwnCloudName($intName, true);
-		if (\is_string($altName) && $mapper->map($dn, $altName, $uuid)) {
-			return $altName;
-		}
-
-		throw new \OutOfBoundsException("Could not create unique name for $dn.");
+		throw new \OutOfBoundsException("Mapping collision for DN $dn and UUID $uuid. Couldnt map to: $intName");
 	}
 
 	/**

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -362,8 +362,8 @@ class Manager {
 
 		//a new user/group! Add it only if it doesn't conflict with other backend's users or existing groups
 		$intName = \trim($this->access->sanitizeUsername($userEntry->getUserId()));
-		if($intName !== '' && $this->access->shouldMapToUsername($intName)) {
-			if($mapper->map($dn, $intName, $uuid)) {
+		if ($intName !== '' && $this->access->shouldMapToUsername($intName)) {
+			if ($mapper->map($dn, $intName, $uuid)) {
 				return $intName;
 			}
 		}

--- a/tests/acceptance/features/apiProvisioningLDAP/groups.feature
+++ b/tests/acceptance/features/apiProvisioningLDAP/groups.feature
@@ -126,7 +126,7 @@ Feature: manage groups
       """
     # In drone the ldap groups have not synced yet. So this occ command is required to sync them.
     And the administrator has invoked occ command "group:list"
-    Then group "db-group_2" should exist
+    Then group "db-group_2" should not exist
 
   Scenario Outline: Add database group with same name as existing ldap group
     Given using OCS API version "<ocs-api-version>"

--- a/tests/acceptance/features/apiUserLDAPConnection/groupFilter.feature
+++ b/tests/acceptance/features/apiUserLDAPConnection/groupFilter.feature
@@ -57,5 +57,4 @@ Feature: filter groups
         | group  |
         | admin  |
         | grp1   |
-        | grp1_2 |
 

--- a/tests/acceptance/features/webUIProvisioning/groups.feature
+++ b/tests/acceptance/features/webUIProvisioning/groups.feature
@@ -31,8 +31,8 @@ Feature: add group
       objectclass: posixGroup
       """
     And the administrator reloads the users page
-    Then the group name "db-group_2" should be listed on the webUI
-    And group "db-group_2" should exist
+    Then the group name "db-group_2" should not be listed on the webUI
+    And group "db-group_2" should not exist
 
   Scenario: delete group
     Given group "simple group" has been created in the database user backend

--- a/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
+++ b/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
@@ -34,22 +34,18 @@ Feature: group membership
     When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
+  Scenario: simple sharing with a group but user no in it
+    When the user shares folder "simple-folder" with group "grp1" using the webUI
+    #ToDo use API calls
+    When the user re-logs in as "user3" using the webUI
+    Then folder "simple-folder (2)" should not be listed on the webUI
+
   Scenario: deleting a group after a folder was shared with that group
     When the user shares folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
     And the administrator deletes ldap group "grp1"
     When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder (2)" should not be listed on the webUI
-
-  @issue-268
-  Scenario: sharing with non unique group name (using unique oC group name)
-    Given the administrator creates group "grp1" in ldap OU "TestUsers"
-    And the administrator adds user "user3" to group "grp1" in ldap OU "TestUsers"
-    And the administrator has invoked occ command "group:list"
-    When the user shares folder "simple-folder" with group "grp1_2" using the webUI
-    #ToDo use API calls
-    When the user re-logs in as "user3" using the webUI
-    Then folder "simple-folder (2)" should be listed on the webUI
 
   Scenario: sharing with non unique group name (using non-unique group name)
     Given the administrator creates group "grp1" in ldap OU "TestUsers"


### PR DESCRIPTION
This PR changes the way the LDAP app creates the mapping entries. I am still evaluating the possible effects of this change. 

Essentially, this allows new LDAP logins to attempt to reuse existing oc_accounts entries that match the resolved username attribute AND have backend = User_Proxy.

This fixes when admins mistakenly delete the user mapping, and logins then create new accounts.

It also allows auto provisioned users with shiboleth me moved over to and LDAP server and continue using owncloud, simply by updating their backend string: `UPDATE oc_accounts SET backend = 'OCA\User_LDAP\User_Proxy' WHERE backend = 'OCA\User_Shibboleth\UserBackend';`

Edit: UPDATED. Now it will fail, and kill crazy names - but if you set oc_appconfig user_ldap `reuse_accounts` then a new mapping is allowed to be created to an existing account.

