### PR TITLE
use user filter when fetching user entry by dn

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -197,7 +197,7 @@ class Manager {
 			$this->getConnection()->getConnectionResource(),
 			$dn,
 			$this->getAttributes(),
-			'objectClass=*',
+			$this->getConnection()->ldapUserFilter,
 			20); // TODO why 20? why is 1 not sufficient?
 		if($result === false || $result['count'] === 0) {
 			// FIXME the ldap error ($result = false) should bubble up ... and not be converted to a DoesNotExistOnLDAPException


### PR DESCRIPTION
without this the user sync will happily use a previously mapped dn to fetch a user entry and ignore any user filter

cc @tomneedham 