### PR TITLE
reallow avatars to be changed if not provided by ldap

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -26,6 +26,7 @@
 namespace OCA\User_LDAP\User;
 
 use OC\Cache\CappedMemoryCache;
+use OC\ServerNotAvailableException;
 use OCA\User_LDAP\Access;
 use OCA\User_LDAP\Connection;
 use OCA\User_LDAP\Exceptions\DoesNotExistOnLDAPException;
@@ -117,11 +118,11 @@ class Manager {
 
 	/**
 	 * @brief checks whether the Access instance has been set
-	 * @throws \Exception if Access has not been set
+	 * @throws \BadMethodCallException if Access has not been set
 	 */
 	private function checkAccess() {
 		if ($this->access === null) {
-			throw new \Exception('LDAP Access instance must be set first');
+			throw new \BadMethodCallException('LDAP Access instance must be set first');
 		}
 	}
 
@@ -188,9 +189,14 @@ class Manager {
 
 	/**
 	 * Gets an UserEntry from the LDAP server from a distinguished name
+	 *
 	 * @param $dn
 	 * @return UserEntry
+	 * @throws \OutOfBoundsException
+	 * @throws \InvalidArgumentException
+	 * @throws \BadMethodCallException
 	 * @throws DoesNotExistOnLDAPException when the dn supplied cannot be found on LDAP
+	 * @throws ServerNotAvailableException
 	 */
 	public function getUserEntryByDn($dn) {
 		$result = $this->access->executeRead(
@@ -211,7 +217,7 @@ class Manager {
 	 * @brief returns a User object by the DN in an ldap entry
 	 * @param array $ldapEntry the ldap entry used to prefill the user properties
 	 * @return \OCA\User_LDAP\User\UserEntry
-	 * @throws \Exception when connection could not be established
+	 * @throws \BadMethodCallException when access object has not been set
 	 * @throws \InvalidArgumentException if entry does not contain a dn
 	 * @throws \OutOfBoundsException when username could not be determined
 	 */

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -33,6 +33,7 @@
 
 namespace OCA\User_LDAP;
 
+use OC\ServerNotAvailableException;
 use OC\User\Backend;
 use OC\User\NoUserException;
 use OCA\User_LDAP\Exceptions\DoesNotExistOnLDAPException;
@@ -174,9 +175,13 @@ class User_LDAP implements IUserBackend, UserInterface {
 
 	/**
 	 * check if a user exists
+	 *
 	 * @param string $uid the username
 	 * @return boolean
-	 * @throws \Exception when connection could not be established
+	 * @throws \OutOfBoundsException
+	 * @throws \InvalidArgumentException
+	 * @throws \BadMethodCallException
+	 * @throws ServerNotAvailableException when connection could not be established
 	 */
 	public function userExists($uid) {
 		// check if an LdapEntry has been cached already

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -236,7 +236,7 @@ class User_Proxy extends Proxy implements
 	 * @throws DoesNotExistOnLDAPException
 	 */
 	public function canChangeAvatar($uid) {
-		foreach($this->backends as $backend) {
+		foreach ($this->backends as $backend) {
 			if ($backend->userExists($uid)) {
 				return $backend->canChangeAvatar($uid);
 			}

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -27,6 +27,8 @@
 
 namespace OCA\User_LDAP;
 
+use OC\ServerNotAvailableException;
+use OCA\User_LDAP\Exceptions\DoesNotExistOnLDAPException;
 use OCP\IConfig;
 use OCP\IUserBackend;
 use OCP\User\IProvidesEMailBackend;
@@ -224,11 +226,22 @@ class User_Proxy extends Proxy implements
 
 	/**
 	 * checks whether the user is allowed to change his avatar in ownCloud
+	 *
 	 * @param string $uid the ownCloud user name
 	 * @return bool either the user can or cannot
+	 * @throws \OutOfBoundsException
+	 * @throws \InvalidArgumentException
+	 * @throws \BadMethodCallException
+	 * @throws ServerNotAvailableException
+	 * @throws DoesNotExistOnLDAPException
 	 */
 	public function canChangeAvatar($uid) {
-		return $this->handleRequest($uid, 'canChangeAvatar', [$uid]);
+		foreach($this->backends as $backend) {
+			if ($backend->userExists($uid)) {
+				return $backend->canChangeAvatar($uid);
+			}
+		}
+		throw new DoesNotExistOnLDAPException($uid);
 	}
 
 	/**


### PR DESCRIPTION
Currently, a user cannot change his avatar. Even if ldap does not provide an avatar.
The handleRequest stuff cannot properly be used for methods that return a boolean.