### PR TITLE
[for reference] Detect LDAP Vendor & Version in wizard

### DIFF
--- a/ajax/wizard.php
+++ b/ajax/wizard.php
@@ -79,6 +79,7 @@ switch($action) {
 	case 'countUsers':
 	case 'countGroups':
 	case 'countInBaseDN':
+	case 'detectVendor':
 		try {
 			$result = $wizard->$action();
 			if($result !== false) {

--- a/js/wizard/wizard.js
+++ b/js/wizard/wizard.js
@@ -19,6 +19,7 @@ OCA = OCA || {};
 
 		var detectors = [];
 		detectors.push(new OCA.LDAP.Wizard.WizardDetectorPort());
+		detectors.push(new OCA.LDAP.Wizard.WizardDetectorVendor());
 		detectors.push(new OCA.LDAP.Wizard.WizardDetectorBaseDN());
 		detectors.push(new OCA.LDAP.Wizard.WizardDetectorEmailAttribute());
 		detectors.push(new OCA.LDAP.Wizard.WizardDetectorUserDisplayNameAttribute());

--- a/js/wizard/wizardTabAbstractFilter.js
+++ b/js/wizard/wizardTabAbstractFilter.js
@@ -72,6 +72,12 @@ OCA = OCA || {};
 		},
 
 		/**
+		 * returns managed item for the vendor. must be
+		 * implemented by concrete view
+		 */
+		getVendorItem: function () {},
+
+		/**
 		 * returns managed item for the object class chooser. must be
 		 * implemented by concrete view
 		 */

--- a/js/wizard/wizardTabElementary.js
+++ b/js/wizard/wizardTabElementary.js
@@ -41,6 +41,12 @@ OCA = OCA || {};
 					setMethod: 'setPort',
 					$relatedElements: $('.ldapDetectPort')
 				},
+				ldap_vendor: {
+					$element: $('#ldap_vendor'),
+					setMethod: 'setVendor',
+					keyName: 'ldap_vendor',
+					featureName: 'DetectVendor'
+				},
 				ldap_dn: {
 					$element: $('#ldap_dn'),
 					setMethod: 'setAgentDN'
@@ -97,6 +103,13 @@ OCA = OCA || {};
 		},
 
 		/**
+		 * returns managed item for the vendor
+		 */
+		getVendorItem: function () {
+			return this.managedItems.ldap_vendor;
+		},
+
+		/**
 		 * updates the host configuration text field
 		 *
 		 * @param {string} host
@@ -117,6 +130,19 @@ OCA = OCA || {};
 		 */
 		setPort: function(port) {
 			this.setElementValue(this.managedItems.ldap_port.$element, port);
+			this.considerFeatureRequests();
+		},
+
+		/**
+		 * updates the port configuration text field
+		 *
+		 * @param {string} vendor
+		 */
+		setVendor: function(vendor) {
+			var vendorString = (vendor.name || t('user_ldap', 'Unknown vendor'))
+				+ ' | '
+				+ (vendor.version || t('user_ldap', 'Unknown version'));
+			this.setElementValue(this.managedItems.ldap_vendor.$element, vendorString);
 		},
 
 		/**
@@ -167,6 +193,24 @@ OCA = OCA || {};
 			);
 		},
 
+		/**
+		 * @inheritdoc
+		 */
+		considerFeatureRequests: function() {
+			if(!this.isActive) {
+				return;
+			}
+			/*
+			if(this.getHost().$element.find('option').length === 0) {
+				this.disableElement(this.getObjectClassItem().$element);
+				this.disableElement(this.getGroupsItem().$element);
+				if(this.parsedFilterMode === this.configModel.FILTER_MODE_ASSISTED) {
+				*/
+					this.configModel.requestWizard(this.getVendorItem().keyName);
+					/*
+				}
+			}*/
+		},
 		/**
 		 * @inheritdoc
 		 */
@@ -287,6 +331,8 @@ OCA = OCA || {};
 					}
 				}
 				OC.Notification.showTemporary(message);
+			} else if (payload.feature === view.getVendorItem().featureName) {
+				view.setVendor(payload.data);
 			}
 		},
 

--- a/lib/Wizard.php
+++ b/lib/Wizard.php
@@ -79,6 +79,38 @@ class Wizard extends LDAPUtility {
 		}
 	}
 
+	public function detectVendor() {
+		if(!$this->checkRequirements(['ldapHost','ldapPort'])) {
+			return  false;
+		}
+		$res = $this->access->executeRead(
+			$this->access->getConnection()->getConnectionResource(),
+			'',
+			['objectclass', 'vendorName', 'vendorVersion', 'orcldirectoryversion', 'isGlobalCatalogReady'],
+			'objectClass=*',
+			1
+		);
+		$name = null;
+		$version = null;
+		if (isset($res['vendorname'][0])) {
+			$name = $res['vendorname'][0];
+		}
+		if (isset($res['vendorversion'][0])) {
+			$version = $res['vendorversion'][0];
+		}
+		if ($version === null && isset($res['objectclass'][1]) && $res['objectclass'][1] === 'OpenLDAProotDSE') {
+			$version = 'OpenLDAP';
+		}
+		if ($version === null && isset($res['isglobalcatalogready'][0])) {
+			$name = 'Microsoft';
+			$version = 'Active Directory';
+		}
+
+		$this->result->addOptions('ldap_vendor', ['name' => $name, 'version' => $version ]);
+		//$this->result->addOptions('ldap_vendor', ['name' => 'somename', 'version' => 'semover 1.2.3' ]);
+		return $this->result;
+	}
+
 	/**
 	 * counts entries in the LDAP directory
 	 *

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -55,6 +55,12 @@
 				</div>
 			</div>
 			<div class="tablerow">
+				<input type="text" id="ldap_vendor" name="ldap_vendor"
+					   class="tablecell" readonly
+					   title="<?php p($l->t('The detected Vendor'));?>"
+				/>
+			</div>
+			<div class="tablerow">
 				<input type="text" id="ldap_dn" name="ldap_dn"
 				class="tablecell"
 				placeholder="<?php p($l->t('User DN'));?>" autocomplete="off"

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -36,6 +36,7 @@ script('user_ldap', [
 	'wizard/wizardDetectorUserGroupAssociation',
 	'wizard/wizardDetectorAvailableAttributes',
 	'wizard/wizardDetectorTestAbstract',
+	'wizard/wizardDetectorVendor',
 	'wizard/wizardDetectorTestLoginName',
 	'wizard/wizardDetectorTestBaseDN',
 	'wizard/wizardDetectorTestConfiguration',


### PR DESCRIPTION
I need to wrap my head around the wizard and config classes and web ui. This PR adds detection of the LDAP vendor and LDAP version ... if the server announces it. OpenLDAP and Active Directory don't ... of course ... they can only be detected by checking additional attributes

Try these public servers in a new empty config with port 389:
```
ldap://directory.d-trust.de // Oracle Corporation | Sun-Directory-Server/11.1.1.7.2
ldap://x500.bund.de // Atos IT Solutions and Services GmbH | DirX Directory V8.3 8.9.310 2014:09:08 20:10 64-Bit
ldap://directory.verisign.com // Red Hat, Inc. | Red Hat-Directory/8.1.0 B2009.111.1832
ldap://ldap.duke.edu // 389 Project | 389-Directory/1.2.11.15 B2015.022.1831
ldap://ldap.forumsys.com // objectclass=OpenLDAProotDSE
ldap://ldap-tiks.telesec.de // objectclass=OpenLDAProotDSE
ldap://www.trustcenter.de // CentOS | CentOS-Directory/8.2.8 B2012.041.1227
```

AD is detected as well but I dont have one I can post as an example.

- [ ] use span instead of input element
- [ ] add this to the configreport

cc @tomneedham @felixheidecke for insights how to add a single thing to the wizard.
