### PR TITLE
Remove comment reference to ldapUserCleanupInterval

### DIFF
--- a/lib/Command/CheckUser.php
+++ b/lib/Command/CheckUser.php
@@ -118,10 +118,6 @@ class CheckUser extends Command {
 				. 'disabled LDAP configurations are present.');
 		}
 
-		// we don't check ldapUserCleanupInterval from config.php because this
-		// action is triggered manually, while the setting only controls the
-		// background job.
-
 		return true;
 	}
 


### PR DESCRIPTION
because ldapUserCleanupInterval does not exist any more.

See core PR https://github.com/owncloud/core/pull/30805
and core issue https://github.com/owncloud/core/issues/30419
and user_ldap issue #179 