### PR TITLE
Displayname nor email won't be editable from the profile page

### DIFF
--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -271,7 +271,6 @@ class User_LDAP implements IUserBackend, UserInterface {
 		return (bool)((Backend::CHECK_PASSWORD
 			| Backend::GET_HOME
 			| Backend::GET_DISPLAYNAME
-			| Backend::SET_DISPLAYNAME // not really, but it is stored in the account table
 			| Backend::PROVIDE_AVATAR
 			| Backend::COUNT_USERS)
 			& $actions);

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -215,10 +215,6 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvides
 		return $this->handleRequest($uid, 'getDisplayName', array($uid));
 	}
 
-	public function setDisplayName($uid, $displayName) {
-		// ignored, function needed to make core store the display name in the account table
-
-	}
 	/**
 	 * checks whether the user is allowed to change his avatar in ownCloud
 	 * @param string $uid the ownCloud user name


### PR DESCRIPTION
Fix https://github.com/owncloud/enterprise/issues/2459 by making the profile read-only for the displayname and email.

Consider this PR as **untested** unless told otherwise.