### PR TITLE
Add longer group names added in core 30798

### DIFF
--- a/tests/acceptance/config/ldap-users.ldif
+++ b/tests/acceptance/config/ldap-users.ldif
@@ -3,6 +3,30 @@ objectclass: top
 objectclass: organizationalUnit
 ou: TestGroups
 
+dn: cn=group1,ou=TestGroups,dc=owncloud,dc=com
+cn: group1
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
+dn: cn=group2,ou=TestGroups,dc=owncloud,dc=com
+cn: group2
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
+dn: cn=group3,ou=TestGroups,dc=owncloud,dc=com
+cn: group3
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
+dn: cn=groupuser,ou=TestGroups,dc=owncloud,dc=com
+cn: groupuser
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
 dn: cn=grp1,ou=TestGroups,dc=owncloud,dc=com
 cn: grp1
 gidnumber: 500


### PR DESCRIPTION
Core PR https://github.com/owncloud/core/pull/30798 used some different and longer group names in acceptance tests that check sharing autocompletion, because now there is a default minimum for that autocompletion lookup and so existing group and user names for tests need to be a decent length.

We can add those here, and also need to keep the other "grp1"... names that are used elsewhere in other acceptance tests. It should all pass with both sets of test groups existing - CI will know.