### PR TITLE
Jump over invalid quota message if quota isn't provided

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,7 +2,7 @@ workspace:
   base: /var/www/owncloud
   path: apps/user_ldap
 
-branches: [master, release*]
+branches: [master, release*, release/*]
 
 pipeline:
   ldap:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [0.11.0] - 
+
 ## [0.10.0] - 2017-12-20
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 	</description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Tom Needham, Juan Pablo Villafañez Ramos, Dominik Schmidt and Arthur Schiwon</author>
-	<version>0.10.0</version>
+	<version>0.11.0</version>
 	<types>
 		<authentication/>
 	</types>

--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -210,7 +210,7 @@ class UserEntry {
 			\OC::$server->getLogger()->debug("No LDAP quota attribute configured", ['app' => 'user_ldap']);
 		} else {
 			$quota = $this->getAttributeValue ($attr);
-			if (!$this->verifyQuotaValue($quota)) {
+			if ($quota !== null && !$this->verifyQuotaValue($quota)) {
 				\OC::$server->getLogger()->error("Invalid quota <$quota> for LDAP user <{$this->getOwnCloudUID()}>", ['app' => 'user_ldap']);
 				$quota = null;
 			}


### PR DESCRIPTION
If the quota isn't set for the user, supress the "invalid quota" log message.

Note: This PR targets release/0.11.0 branch.