### PR TITLE
Include an exact match of the search term for the uuid attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
+## [0.11.0] - 
+
 ## [0.10.0] - 2017-12-20
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 	</description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Tom Needham, Juan Pablo Villafañez Ramos, Dominik Schmidt and Arthur Schiwon</author>
-	<version>0.10.0</version>
+	<version>0.11.0</version>
 	<types>
 		<authentication/>
 	</types>


### PR DESCRIPTION
Fix user:sync by allowing searching by the uuid (exact match)