### PR TITLE
Jump over invalid quota message if quota isn't provided

### DIFF
--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -210,7 +210,7 @@ class UserEntry {
 			\OC::$server->getLogger()->debug("No LDAP quota attribute configured", ['app' => 'user_ldap']);
 		} else {
 			$quota = $this->getAttributeValue($attr);
-			if (!$this->verifyQuotaValue($quota)) {
+			if ($quota !== null && !$this->verifyQuotaValue($quota)) {
 				\OC::$server->getLogger()->error("Invalid quota <$quota> for LDAP user <{$this->getOwnCloudUID()}>", ['app' => 'user_ldap']);
 				$quota = null;
 			}


### PR DESCRIPTION
If the quota isn't set for the user, supress the "invalid quota" log message.

Superseds https://github.com/owncloud/user_ldap/pull/235