### PR TITLE
Restore avatar behaviour of OC 9.1

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -240,6 +240,11 @@ class Manager {
 			return $this->usersByUid[$uid];
 		}
 
+		$dn = $this->username2dn($uid);
+		if ($dn) {
+			return $this->getUserEntryByDn($dn);
+		}
+
 		// should have been cached during login or while iterating over multiple users, eg during sync
 		$this->logger->warning('No cached ldap result found for '. $uid , ['app' => self::class]);
 		return null;

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -240,9 +240,16 @@ class Manager {
 			return $this->usersByUid[$uid];
 		}
 
-		$dn = $this->username2dn($uid);
-		if ($dn) {
-			return $this->getUserEntryByDn($dn);
+		try {
+			$dn = $this->username2dn($uid);
+			if ($dn) {
+				return $this->getUserEntryByDn($dn);
+			}
+		} catch (DoesNotExistOnLDAPException $e) {
+			return null;
+		} catch (\OutOfBoundsException $e) {
+			// dn might be outside of the base
+			return null;
 		}
 
 		// should have been cached during login or while iterating over multiple users, eg during sync

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -104,7 +104,7 @@ class User_LDAP implements IUserBackend, UserInterface {
 			return false;
 		}
 
-		if($userEntry->getAvatarImage() === false) {
+		if($userEntry->getAvatarImage() === null) {
 			return true;
 		}
 

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -221,7 +221,7 @@ class User_Proxy extends Proxy implements IUserBackend, UserInterface, IProvides
 	 * @return bool either the user can or cannot
 	 */
 	public function canChangeAvatar($uid) {
-		return $this->handleRequest($uid, 'canChangeAvatar', array($uid), true);
+		return $this->handleRequest($uid, 'canChangeAvatar', array($uid));
 	}
 
 	/**

--- a/tests/unit/User/ManagerTest.php
+++ b/tests/unit/User/ManagerTest.php
@@ -453,4 +453,60 @@ class ManagerTest extends \Test\TestCase {
 
 		$this->assertNull($this->manager->getCachedEntry('usertest'));
 	}
+
+	public function testGetCachedEntryMissingEntry() {
+		$this->access->expects($this->once())
+			->method('username2dn')
+			->with('usertest')
+			->willReturn('uid=usertest,ou=users,dc=example,dc=com');
+
+		$this->access->method('executeRead')
+			->with($this->anything(), 'uid=usertest,ou=users,dc=example,dc=com', $this->anything(), $this->anything(), $this->anything())
+			->willReturn(false);
+
+		$this->assertNull($this->manager->getCachedEntry('usertest'));
+	}
+
+	public function testGetCachedEntryOutsideOfBase() {
+		$this->access->expects($this->once())
+			->method('username2dn')
+			->with('usertest')
+			->willReturn('uid=usertest,ou=users,dc=example,dc=com');
+
+		$this->access->method('executeRead')
+			->with($this->anything(), 'uid=usertest,ou=users,dc=example,dc=com', $this->anything(), $this->anything(), $this->anything())
+			->willReturn([
+				'count' => 5,
+				0 => 'dn',
+				'dn' => [
+					'count' => 1,
+					0 => 'uid=usertest,ou=users,dc=example,dc=com',
+				],
+				1 => 'uid',
+				'uid' => [
+					'count' => 1,
+					0 => 'usertest',
+				],
+				2 => 'displayname',
+				'displayname' => [
+					'count' => 0,
+					0 => 'Test user',
+				],
+				3 => 'quota',
+				'quota' => [
+					'count' => 1,
+					0 => '7GB',
+				],
+				4 => 'mail',
+				'mail' => [
+					'count' => 1,
+					0 => 'usertest@example.com',
+				],
+			]);
+
+		$this->access->method('isDNPartOfBase')
+			->willReturn(false);
+
+		$this->assertNull($this->manager->getCachedEntry('usertest'));
+	}
 }

--- a/tests/unit/User_LDAPTest.php
+++ b/tests/unit/User_LDAPTest.php
@@ -328,4 +328,33 @@ class User_LDAPTest extends \Test\TestCase {
 
 		$this->assertFalse($this->backend->countUsers());
 	}
+
+	public function testCanChangeAvatarNotCached() {
+		$this->manager->method('getCachedEntry')
+			->willReturn(null);
+
+		$this->assertFalse($this->backend->canChangeAvatar('usertest'));
+	}
+
+	public function testCanChangeAvatarNoLdapImage() {
+		$userEntry = $this->createMock(UserEntry::class);
+		$userEntry->method('getAvatarImage')
+			->willReturn(null);
+
+		$this->manager->method('getCachedEntry')
+			->willReturn($userEntry);
+
+		$this->assertTrue($this->backend->canChangeAvatar('usertest'));
+	}
+
+	public function testCanChangeAvatarImageSet() {
+		$userEntry = $this->createMock(UserEntry::class);
+		$userEntry->method('getAvatarImage')
+			->willReturn('binaryDataForImageAsStringEncoded');
+
+		$this->manager->method('getCachedEntry')
+			->willReturn($userEntry);
+
+		$this->assertFalse($this->backend->canChangeAvatar('usertest'));
+	}
 }


### PR DESCRIPTION
Fix https://github.com/owncloud/enterprise/issues/2553

Checked against OC 10.0.9RC2. There shouldn't be any extra core requirement.