### PR TITLE
fix behat extensions use

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -1,8 +1,6 @@
 default:
   autoload:
     '': %paths.base%/../features/bootstrap
-  extensions:
-    SensioLabs\Behat\PageObjectExtension: ~
 
   suites:
     webUICore:
@@ -55,3 +53,10 @@ default:
         - WebUIUserContext:
         - WebUISharingContext:
         - WebUIFilesContext:
+
+  extensions:
+      jarnaiz\JUnitFormatter\JUnitFormatterExtension:
+          filename: report-user_ldap.xml
+          outputDir: %paths.base%/../../../../../tests/acceptance/output/
+
+      rdx\behatvars\BehatVariablesExtension: ~


### PR DESCRIPTION
we don't need to enable `PageObjectExtension` here, as its already enabled by `run.sh`
but we need the junit extension, as `run.sh` starts behat with `-f junit` and without configuring the path the extension will try to write to `/webuicore.xml`