### PR TITLE
always use occ by testing app

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -12,9 +12,6 @@ default:
         - %paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers
       context: &common_webui_suite_context
         parameters:
-          ocPath: apps/testing/api/v1/occ
-          adminUsername: admin
-          adminPassword: admin
           ldapAdminUser: cn=admin,dc=owncloud,dc=com
           ldapAdminPassword: admin
           ldapBaseDN: dc=owncloud,dc=com
@@ -31,7 +28,7 @@ default:
             adminUsername: admin
             adminPassword: admin
             regularUserPassword: 123456
-            ocPath: ../../../../
+            ocPath: apps/testing/api/v1/occ
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIFilesContext:

--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -392,8 +392,10 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 		$this->ldap = new Zend\Ldap\Ldap($options);
 		$this->ldap->bind();
 		SetupHelper::init(
-			"admin", (string)$suiteParameters['adminPassword'],
-			$this->featureContext->getBaseUrl(), $suiteParameters['ocPath']
+			$this->featureContext->getAdminUsername(),
+			$this->featureContext->getAdminPassword(),
+			$this->featureContext->getBaseUrl(),
+			$this->featureContext->getOcPath()
 		);
 	}
 


### PR DESCRIPTION
after https://github.com/owncloud/core/pull/32239 we can always use the remote version of occ by the testing app