### PR TITLE
Remove unneeded SKELETON_DIR in .drone.yml

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -68,7 +68,6 @@ pipeline:
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
       - TEST_SERVER_FED_URL=http://federated
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=webUIUserLDAP
@@ -91,7 +90,6 @@ pipeline:
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
       - TEST_SERVER_FED_URL=http://federated
-      - SKELETON_DIR=/var/www/owncloud/tests/acceptance/webUISkeleton
       - PLATFORM=Linux
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=webUICore


### PR DESCRIPTION
SKELETON_DIR should have a correct default value in ``run.sh``, so it should not be needed here.

This will effectively implement the recent change of SKELETON_DIR location in core.