### PR TITLE
Dont throw exception when user not found on ldap during login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /vendor/
 .php_cs.cache
+/tests/output/

--- a/Makefile
+++ b/Makefile
@@ -134,3 +134,7 @@ test-php-lint: $(composer_dev_deps)
 .PHONY: test-php-style
 test-php-style: $(composer_dev_deps)
 	$(composer_deps)/bin/php-cs-fixer fix -v --diff --dry-run --allow-risky yes
+
+.PHONY: test-php
+test-php: $(composer_dev_deps)
+	PHPUNIT=$() cd tests/unit && phpunit

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/owncloud/user_ldap/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/owncloud/user_ldap/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/owncloud/user_ldap/badges/build.png?b=master)](https://scrutinizer-ci.com/g/owncloud/user_ldap/build-status/master)
 
+## Running Tests
+
+PHPUnit tests: `make test-php`
+
 #### Additional configuration options that can be added to config.php
 
 * `'user_ldap.enable_medial_search' => true`

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -423,14 +423,14 @@ class Manager {
 	 *
 	 * @param string $loginName
 	 * @return UserEntry
-	 * @throws \Exception
+	 * @throws DoesNotExistOnLDAPException
 	 */
 	public function getLDAPUserByLoginName($loginName) {
 		//find out dn of the user name
 		$attrs = $this->getAttributes();
 		$users = $this->access->fetchUsersByLoginName($loginName, $attrs);
 		if (\count($users) < 1) {
-			throw new \Exception('No user available for the given login name on ' .
+			throw new DoesNotExistOnLDAPException('No user available for the given login name on ' .
 				$this->getConnection()->ldapHost . ':' . $this->getConnection()->ldapPort);
 		}
 		return $this->getFromEntry($users[0]);

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -137,7 +137,10 @@ class User_LDAP implements IUserBackend, UserInterface {
 	public function checkPassword($uid, $password) {
 		try {
 			$userEntry = $this->userManager->getLDAPUserByLoginName($uid);
+		} catch (DoesNotExistOnLDAPException $e) {
+			return false;
 		} catch (\Exception $e) {
+			// Something more serious than not found occured
 			\OC::$server->getLogger()->logException($e, ['app' => 'user_ldap']);
 			return false;
 		}

--- a/tests/unit/User_LDAPTest.php
+++ b/tests/unit/User_LDAPTest.php
@@ -83,6 +83,16 @@ class User_LDAPTest extends \Test\TestCase {
 		$this->assertEquals('563418fc-423b-1033-8d1c-ad5f418ee02e', $result);
 	}
 
+	public function testCheckPasswordDoesntExistDoesntLog() {
+		$this->manager->expects($this->once())
+			->method('getLDAPUserByLoginName')
+			->with($this->equalTo('foo'))
+			->willThrowException(new DoesNotExistOnLDAPException());
+		$result = $this->backend->checkPassword('foo', 'secret');
+		$this->manager->expects($this->never())->method('areCredentialsValid');
+		$this->assertEquals(false, $result);
+	}
+
 	public function testCheckPasswordWrongPassword() {
 		$userEntry = $this->createMock(UserEntry::class);
 		$userEntry->expects($this->any())


### PR DESCRIPTION
When we try to login, we do a lookup on the LDAP server. Unfortunately when not found it just threw a basic exception which could be the same as connection error etc. So I swapped it to use the proper DoesNotExistOnLDAPException and catch this and not log it, but still log other exceptions.