### PR TITLE
su-exec www-data is not needed for acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ pipeline:
       - BEHAT_SUITE=webUIUserLDAP
     commands:
       - cd /var/www/owncloud/tests/acceptance
-      - su-exec www-data ./run.sh --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml
+      - ./run.sh --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml
     when:
       matrix:
         TEST_SOURCE: ldap
@@ -110,7 +110,7 @@ pipeline:
       - BEHAT_SUITE=webUICore
     commands:
       - cd /var/www/owncloud/tests/acceptance
-      - su-exec www-data ./run.sh --remote --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml --tags '@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&~@skip'
+      - ./run.sh --remote --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml --tags '@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&~@skip'
     when:
       matrix:
         TEST_SOURCE: core-webUI
@@ -125,7 +125,7 @@ pipeline:
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
       - cd /var/www/owncloud/tests/acceptance
-      - su-exec www-data ./run.sh --remote --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml --tags '@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&~@skip'
+      - ./run.sh --remote --config /var/www/owncloud/apps/user_ldap/tests/acceptance/config/behat.yml --tags '@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&~@skip'
     when:
       matrix:
         TEST_SOURCE: core-api


### PR DESCRIPTION
After recent core changes to the way the ``local_storage`` folder is created, this passes.
The test runner script can do everything it needs by using the testing app.