### PR TITLE
Disable parallel paginated search for multi base dn on subsequent pages

### DIFF
--- a/lib/Access.php
+++ b/lib/Access.php
@@ -880,7 +880,19 @@ class Access implements IUserTools {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function searchUsers($filter, $attr = null, $limit = null, $offset = null) {
-		return $this->search($filter, $this->connection->ldapBaseUsers, $attr, $limit, $offset);
+		$entries = [];
+		$bases = $this->connection->ldapBaseUsers;
+		// disable parallel paginated search on subsequent pages
+		if ($offset !== null && $offset > 0) {
+			foreach ($bases as $base) {
+				foreach ($this->search($filter, [$base], $attr, $limit, $offset) as $entry) {
+					$entries[] = $entry;
+				}
+			}
+		} else {
+			$entries = $this->search($filter, $bases, $attr, $limit, $offset);
+		}
+		return $entries;
 	}
 
 	/**
@@ -892,7 +904,13 @@ class Access implements IUserTools {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function countUsers($filter, $attr = ['dn'], $limit = null, $offset = null) {
-		return $this->count($filter, $this->connection->ldapBaseUsers, $attr, $limit, $offset);
+		$entries = 0;
+		$bases = $this->connection->ldapBaseUsers;
+		foreach ($bases as $base) {
+			$e = $this->count($filter, [$base], $attr, $limit, $offset);
+			$entries += $e;
+		}
+		return $entries;
 	}
 
 	/**
@@ -908,7 +926,19 @@ class Access implements IUserTools {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function searchGroups($filter, $attr = null, $limit = null, $offset = null) {
-		return $this->search($filter, $this->connection->ldapBaseGroups, $attr, $limit, $offset);
+		$entries = [];
+		$bases = $this->connection->ldapBaseGroups;
+		// disable parallel paginated search on subsequent pages
+		if ($offset !== null && $offset > 0) {
+			foreach ($bases as $base) {
+				foreach ($this->search($filter, [$base], $attr, $limit, $offset) as $entry) {
+					$entries[] = $entry;
+				}
+			}
+		} else {
+			$entries = $this->search($filter, $bases, $attr, $limit, $offset);
+		}
+		return $entries;
 	}
 
 	/**
@@ -922,7 +952,13 @@ class Access implements IUserTools {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function countGroups($filter, $attr = ['dn'], $limit = null, $offset = null) {
-		return $this->count($filter, $this->connection->ldapBaseGroups, $attr, $limit, $offset);
+		$entries = 0;
+		$bases = $this->connection->ldapBaseGroups;
+		foreach ($bases as $base) {
+			$e = $this->count($filter, [$base], $attr, $limit, $offset);
+			$entries += $e;
+		}
+		return $entries;
 	}
 
 	/**
@@ -934,7 +970,13 @@ class Access implements IUserTools {
 	 * @throws \OC\ServerNotAvailableException
 	 */
 	public function countObjects($limit = null, $offset = null) {
-		return $this->count('objectclass=*', $this->connection->ldapBase, ['dn'], $limit, $offset);
+		$entries = 0;
+		$bases = $this->connection->ldapBase;
+		foreach ($bases as $base) {
+			$e = $this->count('objectclass=*', [$base], ['dn'], $limit, $offset);
+			$entries += $e;
+		}
+		return $entries;
 	}
 
 	/**

--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -377,6 +377,12 @@ class Group_LDAP implements \OCP\GroupInterface {
 	/**
 	 * returns a list of users that have the given group as primary group
 	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
 	 * @param string $groupDN
 	 * @param string $search
 	 * @param int $limit
@@ -400,6 +406,12 @@ class Group_LDAP implements \OCP\GroupInterface {
 
 	/**
 	 * returns the number of users that have the given group as primary group
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
 	 *
 	 * @param string $groupDN
 	 * @param string $search
@@ -599,6 +611,12 @@ class Group_LDAP implements \OCP\GroupInterface {
 	/**
 	 * get a list of all users in a group
 	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
 	 * @param string $gid
 	 * @param string $search
 	 * @param int $limit
@@ -776,6 +794,12 @@ class Group_LDAP implements \OCP\GroupInterface {
 	/**
 	 * get a list of all groups
 	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
 	 * @param string $search
 	 * @param $limit
 	 * @param int $offset
@@ -819,15 +843,21 @@ class Group_LDAP implements \OCP\GroupInterface {
 	/**
 	 * get a list of all groups using a paged search
 	 *
-	 * @param string $search
-	 * @param int $limit
-	 * @param int $offset
-	 * @return array with group names
-	 *
 	 * Returns a list with all groups
 	 * Uses a paged search if available to override a
 	 * server side search limit.
 	 * (active directory has a limit of 1000 by default)
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
+	 * @param string $search
+	 * @param int $limit
+	 * @param int $offset
+	 * @return array with group names
 	 */
 	public function getGroups($search = '', $limit = -1, $offset = 0) {
 		if (!$this->enabled) {

--- a/lib/Group_Proxy.php
+++ b/lib/Group_Proxy.php
@@ -157,10 +157,19 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface {
 	}
 
 	/**
-	 * get a list of all groups
-	 * @return string[] with group names
+	 * Get a list of all groups for LDAP base DNs across configured servers.
 	 *
-	 * Returns a list with all groups
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
+	 * @param string $search
+	 * @param null|int $limit
+	 * @param null|int $offset
+	 * @return string[] an array of gids returned by all base DNs queried
+	 * 					individually for specified search, limit and offset
 	 */
 	public function getGroups($search = '', $limit = -1, $offset = 0) {
 		$groups = [];

--- a/lib/Group_Proxy.php
+++ b/lib/Group_Proxy.php
@@ -130,6 +130,17 @@ class Group_Proxy extends Proxy implements \OCP\GroupInterface {
 
 	/**
 	 * get a list of all users in a group
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs across configured servers,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
+	 * @param string $gid
+	 * @param string $search
+	 * @param null|int $limit
+	 * @param null|int $offset
 	 * @return string[] with user ids
 	 */
 	public function usersInGroup($gid, $search = '', $limit = -1, $offset = 0) {

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -163,6 +163,12 @@ class User_LDAP implements IUserBackend, UserInterface {
 	/**
 	 * Get a list of all users
 	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
 	 * @param string $search
 	 * @param integer $limit
 	 * @param integer $offset
@@ -250,6 +256,12 @@ class User_LDAP implements IUserBackend, UserInterface {
 
 	/**
 	 * Get a list of all display names
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs in this server,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
 	 *
 	 * @param string $search
 	 * @param string|null $limit

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -149,15 +149,22 @@ class User_Proxy extends Proxy implements
 	}
 
 	/**
-	 * Get a list of all users
+	 * Get a list of all users for all LDAP base DNs across configured servers.
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
 	 *
 	 * @param string $search
 	 * @param null|int $limit
 	 * @param null|int $offset
-	 * @return string[] an array of all uids
+	 * @return string[] an array of uids returned by all base DNs queried
+	 * 					individually for specified search, limit and offset
 	 */
 	public function getUsers($search = '', $limit = 10, $offset = 0) {
-		//we do it just as the /OC_User implementation: do not play around with limit and offset but ask all backends
+		// we do it just as the /OC_User implementation: do not play around with limit and offset but ask all backends
 		$users = [];
 		foreach ($this->backends as $backend) {
 			$backendUsers = $backend->getUsers($search, $limit, $offset);

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -152,7 +152,7 @@ class User_Proxy extends Proxy implements
 	 * Get a list of all users for all LDAP base DNs across configured servers.
 	 *
 	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
-	 * will search in parallel all provided base DNs,
+	 * will search in parallel all provided base DNs across configured servers,
 	 * and thus can return more then LIMIT $limit users. This function shall
 	 * be used with limit and offset by iterators that can
 	 * support this kind of parallel paging.
@@ -253,6 +253,13 @@ class User_Proxy extends Proxy implements
 
 	/**
 	 * Get a list of all display names and user ids.
+	 *
+	 * WARNING: Using this function combined with LIMIT $limit and OFFSET $offset
+	 * will search in parallel all provided base DNs across configured servers,
+	 * and thus can return more then LIMIT $limit users. This function shall
+	 * be used with limit and offset by iterators that can
+	 * support this kind of parallel paging.
+	 *
 	 * @param string $search
 	 * @param string|null $limit
 	 * @param string|null $offset

--- a/tests/integration/AbstractIntegrationTest.php
+++ b/tests/integration/AbstractIntegrationTest.php
@@ -45,13 +45,21 @@ abstract class AbstractIntegrationTest {
 	protected $userManager;
 
 	/** @var  string */
-	protected $base;
+	protected $bdn;
+
+	/** @var  string */
+	protected $bdnUsers;
+
+	/** @var  string */
+	protected $bdnGroups;
 
 	/** @var string[] */
 	protected $server;
 
-	public function __construct($host, $port, $bind, $pwd, $base) {
+	public function __construct($host, $port, $bind, $pwd, $base, $baseUsers = null, $baseGroups = null) {
 		$this->base = $base;
+		$this->bdnUsers = $baseUsers === null ? $base : $baseUsers;
+		$this->bdnGroups = $baseGroups === null ? $base : $baseGroups;
 		$this->server = [
 			'host' => $host,
 			'port' => $port,
@@ -94,7 +102,9 @@ abstract class AbstractIntegrationTest {
 		$this->connection->setConfiguration([
 			'ldapHost' => $this->server['host'],
 			'ldapPort' => $this->server['port'],
-			'ldapBase' => $this->base,
+			'ldapBase' => $this->bdn,
+			'ldapBaseUsers' => $this->bdnUsers,
+			'ldapBaseGroups' => $this->bdnGroups,
 			'ldapAgentName' => $this->server['dn'],
 			'ldapAgentPassword' => $this->server['pwd'],
 			'ldapUserFilter' => 'objectclass=inetOrgPerson',

--- a/tests/integration/setup-scripts/createExplicitUsers.php
+++ b/tests/integration/setup-scripts/createExplicitUsers.php
@@ -35,26 +35,42 @@ if (!$ok) {
 	die(1);
 }
 
-$ouName = 'users';
-$ouDN = 'ou=' . $ouName . ',' . $bdn;
+$ouNameUsers = 'users';
+$ouDNUsers = 'ou=' . $ouNameUsers . ',' . $bdn;
 
 //creates on OU
 if (true) {
 	$entry = [];
 	$entry['objectclass'][] = 'top';
 	$entry['objectclass'][] = 'organizationalunit';
-	$entry['ou'] = $ouName;
-	$b = \ldap_add($cr, $ouDN, $entry);
+	$entry['ou'] = $ouNameUsers;
+	$b = \ldap_add($cr, $ouDNUsers, $entry);
 	if (!$b) {
 		echo \ldap_error($cr);
 		die(1);
 	}
 }
 
-$users = ['alice', 'boris', 'carl'];
+$ouNameAdmins = 'admins';
+$ouDNAdmins = 'ou=' . $ouNameAdmins . ',' . $bdn;
 
-foreach ($users as $uid) {
-	$newDN = 'uid=' . $uid . ',' . $ouDN;
+//creates on OU
+if (true) {
+	$entry = [];
+	$entry['objectclass'][] = 'top';
+	$entry['objectclass'][] = 'organizationalunit';
+	$entry['ou'] = $ouNameAdmins;
+	$b = \ldap_add($cr, $ouDNAdmins, $entry);
+	if (!$b) {
+		echo \ldap_error($cr);
+		die(1);
+	}
+}
+
+$users = ['alice' => $ouDNUsers, 'boris' => $ouDNUsers, 'carl' => $ouDNUsers, 'admin1' => $ouDNAdmins, 'admin2' => $ouDNAdmins];
+
+foreach ($users as $uid => $userOU) {
+	$newDN = 'uid=' . $uid . ',' . $userOU;
 	$fn = \ucfirst($uid);
 	$sn = \ucfirst(\str_shuffle($uid));   // not so explicit but it's OK.
 


### PR DESCRIPTION
When multiple base dns are configured the `AllUsersIterator` uses pages of 500 to page through the ldap results. It literally provides limit and offset:

https://github.com/owncloud/core/blob/d2697818a682904a13ba8d18e96411722853dd8a/lib/private/User/Sync/AllUsersIterator.php#L40-L47

That confuses the internal parralel seach cookie handling:
1. the first base dn tree only contains ... say 3 results.
2. the second base dn tree contains 1000
the first one will have no further results after the first page, causing the search to be abandoned -> which means all cookies are removed. even for the second base dn tree.

while that shouldn't matter, the next page starts with offset 500.

again, the first base dn tree has no results, abandoning the search and deleting all cookies ... so the sync has no chance of iterating over all pages.

something like that ... It is not 100% correct because it is hard to follow the code path. I need to build a test to cover this automatically.

