### PR TITLE
Adjust acceptance test step text similar to core

### DIFF
--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -54,7 +54,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	private $featureContext;
 	
 	/**
-	 * @Given the LDAP config :configId has the key :configKey set to :configValue
+	 * @Given LDAP config :configId has key :configKey set to :configValue
 	 *
 	 * @param string $configId
 	 * @param string $configKey
@@ -62,7 +62,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 *
 	 * @return void
 	 */
-	public function theLdapConfigHasTheKeySetTo(
+	public function ldapConfigHasKeySetTo(
 		$configId, $configKey, $configValue
 	) {
 		//remember old settings to be able to set them back after test run
@@ -85,16 +85,16 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Given the LDAP config :configId has these settings:
+	 * @Given LDAP config :configId has these settings:
 	 *
 	 * @param string $configId
 	 * @param TableNode $table with the headings |key | value |
 	 *
 	 * @return void
 	 */
-	public function theLdapConfigHasTheseSettings($configId, TableNode $table) {
+	public function ldapConfigHasTheseSettings($configId, TableNode $table) {
 		foreach ($table as $line) {
-			$this->theLdapConfigHasTheKeySetTo(
+			$this->ldapConfigHasKeySetTo(
 				$configId, $line['key'], $line['value']
 			);
 		}

--- a/tests/acceptance/features/bootstrap/UserLdapUsersContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapUsersContext.php
@@ -38,7 +38,7 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	private $userLdapGeneralContext;
 	
 	/**
-	 * @When the administrator creates the group :group in the ldap OU :ou
+	 * @When the administrator creates group :group in ldap OU :ou
 	 *
 	 * @param string $group
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used
@@ -63,8 +63,8 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @When the administrator adds the user :user to the ldap group :group
-	 * @When the administrator adds the user :user to the group :group in the ldap OU :ou
+	 * @When the administrator adds user :user to ldap group :group
+	 * @When the administrator adds user :user to group :group in ldap OU :ou
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -83,8 +83,8 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	}
 	
 	/**
-	 * @When the administrator removes user :user from the ldap group :group
-	 * @When the administrator removes user :user from the group :group in the ldap OU :ou
+	 * @When the administrator removes user :user from ldap group :group
+	 * @When the administrator removes user :user from group :group in ldap OU :ou
 	 *
 	 * @param string $user
 	 * @param string $group
@@ -102,8 +102,8 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the administrator deletes the ldap group :group
-	 * @When the administrator deletes the group :group in the ldap OU :ou
+	 * @When the administrator deletes ldap group :group
+	 * @When the administrator deletes group :group in ldap OU :ou
 	 *
 	 * @param string $group
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used

--- a/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
+++ b/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
@@ -14,53 +14,53 @@ Feature: group membership
     And user "user1" has logged in using the webUI
 
   Scenario: adding a new user to a group after a folder was shared with that group
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
-    And the administrator adds the user "user3" to the ldap group "grp1"
+    And the administrator adds user "user3" to ldap group "grp1"
     When the user re-logs in as "user3" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
     And the folder "simple-folder (2)" should be marked as shared with "grp1" by "User One" on the webUI
 
   Scenario: deleting a user from a group after a folder was shared with that group
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
-    And the administrator removes user "user2" from the ldap group "grp1"
+    And the administrator removes user "user2" from ldap group "grp1"
     When the user re-logs in as "user2" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
 
   Scenario: simple sharing with a group
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
     When the user re-logs in as "user2" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   Scenario: deleting a group after a folder was shared with that group
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
-    And the administrator deletes the ldap group "grp1"
+    And the administrator deletes ldap group "grp1"
     When the user re-logs in as "user2" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
 
   Scenario: sharing with non unique group name (using unique oC group name)
-    Given the administrator creates the group "grp1" in the ldap OU "TestUsers"
-    And the administrator adds the user "user3" to the group "grp1" in the ldap OU "TestUsers"
-    When the user shares the folder "simple-folder" with the group "grp1_2" using the webUI
+    Given the administrator creates group "grp1" in ldap OU "TestUsers"
+    And the administrator adds user "user3" to group "grp1" in ldap OU "TestUsers"
+    When the user shares the folder "simple-folder" with group "grp1_2" using the webUI
     #ToDo use API calls
     When the user re-logs in as "user3" using the webUI
     Then the folder "simple-folder (2)" should be listed on the webUI
 
   Scenario: sharing with non unique group name (using non-unique group name)
-    Given the administrator creates the group "grp1" in the ldap OU "TestUsers"
-    And the administrator adds the user "user3" to the group "grp1" in the ldap OU "TestUsers"
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
+    Given the administrator creates group "grp1" in ldap OU "TestUsers"
+    And the administrator adds user "user3" to group "grp1" in ldap OU "TestUsers"
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
     #ToDo use API calls
     When the user re-logs in as "user3" using the webUI
     Then the folder "simple-folder (2)" should not be listed on the webUI
 
   Scenario: sharing with a group that is filtered out
     #ToDo use API calls
-    When the user shares the folder "simple-folder" with the group "grp1" using the webUI
-    And the LDAP config "LDAPTestId" has these settings:
+    When the user shares the folder "simple-folder" with group "grp1" using the webUI
+    And LDAP config "LDAPTestId" has these settings:
       | key                   | value                                        |
       | ldapGroupFilter       | (&(\|(objectclass=posixGroup))(\|(cn=grp2))) |
       | ldapGroupFilterGroups | grp2                                         |
@@ -69,7 +69,7 @@ Feature: group membership
 
   Scenario: search for groups by alternative attribute
     #ToDo use API calls
-    Given the LDAP config "LDAPTestId" has these settings:
+    Given LDAP config "LDAPTestId" has these settings:
       | key                          | value       |
       | ldapAttributesForGroupSearch | description |
     # Ensure that the test code is aware of the users and groups that exist

--- a/tests/acceptance/features/webUIUserLDAP/loginUsingEmailAddress.feature
+++ b/tests/acceptance/features/webUIUserLDAP/loginUsingEmailAddress.feature
@@ -10,21 +10,21 @@ Feature: login users
     Then it should be possible to login with the username "user1@example.org" and password "%alt1%" using the WebUI
 
   Scenario: using ldap filter including email field
-    When the LDAP config "LDAPTestId" has these settings:
+    When LDAP config "LDAPTestId" has these settings:
       | key                | value                                                                            |
       | ldapLoginFilter    | (&(objectclass=inetOrgPerson)(\|(uid=%uid)(mailPrimaryAddress=%uid)(mail=%uid))) |
       | ldapEmailAttribute |                                                                                  |
     Then it should be possible to login with the username "user1@example.org" and password "%alt1%" using the WebUI
 
   Scenario: using ldapEmailAttribute but loginFilter lacks email field
-    When the LDAP config "LDAPTestId" has these settings:
+    When LDAP config "LDAPTestId" has these settings:
       | key                | value                                    |
       | ldapLoginFilter    | (&(objectclass=inetOrgPerson)(uid=%uid)) |
       | ldapEmailAttribute | mail                                     |
     Then it should be possible to login with the username "user1@example.org" and password "%alt1%" using the WebUI
 
   Scenario: no ldapEmailAttribute and loginFilter lacks email field
-    When the LDAP config "LDAPTestId" has these settings:
+    When LDAP config "LDAPTestId" has these settings:
       | key                | value                                    |
       | ldapLoginFilter    | (&(objectclass=inetOrgPerson)(uid=%uid)) |
       | ldapEmailAttribute |                                          |

--- a/tests/acceptance/features/webUIUserLDAP/paging.feature
+++ b/tests/acceptance/features/webUIUserLDAP/paging.feature
@@ -6,7 +6,7 @@ Feature: paging
   So that all LDAP users get synced over to owncloud
 
   Background:
-    Given the LDAP config "LDAPTestId" has the key "ldapPagingSize" set to "10"
+    Given LDAP config "LDAPTestId" has key "ldapPagingSize" set to "10"
     And the administrator has created "200" LDAP users with the prefix "my-user-" in the OU "NEWZombies"
 
   Scenario: login to a system with a lot of users


### PR DESCRIPTION
Some changes are required because core steps had ``the`` removed yesterday.
Other changes make the LDAP-specific steps similar to what was done in core.