### PR TITLE
Fix acceptance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ test-acceptance-cli: $(composer_dev_deps)
 .PHONY: test-acceptance-ldap
 test-acceptance-ldap: ## Run LDAP acceptance tests
 test-acceptance-ldap: $(composer_dev_deps)
-	../../tests/acceptance/run.sh tests/acceptance/features
+	../../tests/acceptance/run.sh --remote --type webui
 
 .PHONY: test-acceptance-webui
 test-acceptance-webui: ## Run webUI acceptance tests

--- a/tests/acceptance/features/bootstrap/bootstrap.php
+++ b/tests/acceptance/features/bootstrap/bootstrap.php
@@ -20,9 +20,7 @@
  *
  */
 
-require __DIR__ . '/../../../../vendor/autoload.php';
-require __DIR__ . '/../../../../../../lib/base.php';
-require __DIR__ . '/../../../../../../lib/composer/autoload.php';
+require_once __DIR__ . '/../../../../../../tests/acceptance/features/bootstrap/bootstrap.php';
 
 $classLoader = new \Composer\Autoload\ClassLoader();
 $classLoader->addPsr4(


### PR DESCRIPTION
1. fixes https://github.com/owncloud/QA/issues/605
2. it should be possible to use `BEHAT_FEATURE` to specify a single file or tests
before that change running ` make test-acceptance-ldap` without `BEHAT_SUITE` would result in
```
  [Behat\Testwork\Suite\Exception\SuiteNotFoundException]               
  `acceptance` suite is not found or has not been properly registered. 
```
now running ` make test-acceptance-ldap` without `BEHAT_SUITE` is possible but `BEHAT_FEATURE` need to be specified. If non of both are specified the command will try to run all suites from the yml file