### PR TITLE
Add WebDavPropertiesContext to behat.yml

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -72,6 +72,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     apiShareOperations:
       paths:
@@ -82,6 +83,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - PublicWebDavContext:
         - TrashbinContext:
+        - WebDavPropertiesContext:
 
     apiSharingNotifications:
       paths:
@@ -120,6 +122,7 @@ default:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - WebDavPropertiesContext:
 
     webUIUserLDAP:
       paths:


### PR DESCRIPTION
for suites that need it.

``WebDavPropertiesContext`` was created in core by:
https://github.com/owncloud/core/pull/34115
https://github.com/owncloud/core/pull/34124
