### PR TITLE
Use occUsersGroupsContext for cli tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -147,6 +147,7 @@ default:
         - UserLdapUsersContext:
         - FeatureContext: *common_feature_context_params
         - EmailContext:
+        - OccUsersGroupsContext:
         - OccContext:
 
   extensions:


### PR DESCRIPTION
Fixes #339

Use `occUsersGroupsContext` in behat.yml instead of `occContext`