### PR TITLE
Add tests for checking if admin can modify LDAP defined attributes

### DIFF
--- a/tests/acceptance/features/cliProvisioning/users.feature
+++ b/tests/acceptance/features/cliProvisioning/users.feature
@@ -61,3 +61,31 @@ Feature: add a user using the using the occ command
     When the LDAP users are resynced
     Then user "user0" should exist
 
+  Scenario: admin tries to modify displayname of user for which an LDAP attribute is specified
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to "ldap user"
+    And the LDAP users are resynced
+    And the administrator changes the display name of user "user1" to "occ user" using the occ command
+    Then the command should have failed with exit code 1
+    And user "user1" should exist
+    And the user attributes returned by the API should include
+    | displayname | ldap user |
+
+  Scenario: admin tries to modify password of user for which an LDAP attribute is specified
+    When the administrator sets the ldap attribute "userpassword" of the entry "uid=user1,ou=TestUsers" to "ldap_password"
+    And the LDAP users are resynced
+    And the administrator resets the password of user "user1" to "occ_password" using the occ command
+    Then the command should have failed with exit code 1
+    And user "user1" should exist
+    And the content of file "textfile0.txt" for user "user1" using password "ldap_password" should be "ownCloud test text file 0" plus end-of-line
+    But user "user1" using password "occ_password" should not be able to download file "textfile0.txt"
+
+  @skip @issue-core-33186
+  Scenario: admin tries to modify mail of user for which an LDAP attribute is specified
+    When the administrator sets the ldap attribute "mail" of the entry "uid=user1,ou=TestUsers" to "ldapuser@oc.com"
+    And the LDAP users are resynced
+    And the administrator changes the email of user "user1" to "occuser@oc.com" using the occ command
+    Then the command should have failed with exit code 1
+    And user "user1" should exist
+    And the user attributes returned by the API should include
+    | email | ldapuser@oc.com|
+


### PR DESCRIPTION
Related to issue #292 
Acceptance tests for checking if modifying the attributes is blocked when LDAP attributes are set for those.