### PR TITLE
extra group:list to sync group information before sharing

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -138,6 +138,7 @@ default:
         - WebUIUserContext:
         - WebUISharingContext:
         - WebUIFilesContext:
+        - OccContext:
 
     apiUserLDAPConnection:
       paths:

--- a/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
+++ b/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
@@ -41,9 +41,11 @@ Feature: group membership
     When the user re-logs in as "user2" using the webUI
     Then folder "simple-folder (2)" should not be listed on the webUI
 
+  @issue-268
   Scenario: sharing with non unique group name (using unique oC group name)
     Given the administrator creates group "grp1" in ldap OU "TestUsers"
     And the administrator adds user "user3" to group "grp1" in ldap OU "TestUsers"
+    And the administrator has invoked occ command "group:list"
     When the user shares folder "simple-folder" with group "grp1_2" using the webUI
     #ToDo use API calls
     When the user re-logs in as "user3" using the webUI


### PR DESCRIPTION
run an extra `occ group:list` before sharing so that the groups are correctly synced
see #268 
fixes #350 