### PR TITLE
Add remaining core suites in user_ldap for testing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1014,6 +1014,39 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiCapabilities
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFavorites
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFederation
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiComments
 
     - TEST_SUITE: acceptance
@@ -1092,6 +1125,28 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTrashbin
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiTags
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiVersions
 
     - TEST_SUITE: acceptance
       TEST_SOURCE: core-api
@@ -1159,7 +1214,40 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiCapabilities
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiComments
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFavorites
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFederation
 
     - TEST_SUITE: acceptance
       TEST_SOURCE: core-api
@@ -1236,7 +1324,29 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiTags
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTrashbin
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiVersions
 
     - TEST_SUITE: acceptance
       TEST_SOURCE: core-api
@@ -1304,7 +1414,40 @@ matrix:
       NEED_CORE: true
       NEED_SERVER: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiCapabilities
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 5.6
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiComments
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 5.6
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFavorites
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 5.6
+      NEED_CORE: true
+      NEED_SERVER: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiFederation
 
     - TEST_SUITE: acceptance
       TEST_SOURCE: core-api
@@ -1381,6 +1524,17 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiTags
+
+    - TEST_SUITE: acceptance
+      TEST_SOURCE: core-api
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 5.6
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTrashbin
 
     - TEST_SUITE: acceptance
@@ -1411,8 +1565,8 @@ matrix:
       DB_TYPE: mysql
       DB_NAME: owncloud
       PHP_VERSION: 5.6
-      NEED_CORE: true
       NEED_SERVER: true
+      NEED_CORE: true
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavOperations
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -35,16 +35,34 @@ default:
         - WebUISharingContext:
         - WebUIUserContext:
 
-    apiMain:
+    apiCapabilities:
       paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/apiMain'
+        - '%paths.base%/../../../../../tests/acceptance/features/apiCapabilities'
       context: *common_ldap_suite_context
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
-        - AppManagementContext:
-        - CardDavContext:
-        - CalDavContext:
+        - CapabilitiesContext:
+
+    apiFavorites:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiFavorites'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - FavoritesContext:
+        - WebDavPropertiesContext:
+
+    apiFederation:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiFederation'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - FederationContext:
+        - WebDavPropertiesContext:
 
     apiComments:
       paths:
@@ -55,6 +73,17 @@ default:
         - FeatureContext: *common_feature_context_params
         - CommentsContext:
         - WebDavPropertiesContext:
+
+    apiMain:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiMain'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - AppManagementContext:
+        - CardDavContext:
+        - CalDavContext:
 
     apiMetadataApps:
       paths:
@@ -104,6 +133,15 @@ default:
         - FeatureContext: *common_feature_context_params
         - NotificationsCoreContext:
 
+    apiTags:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiTags'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - TagsContext:
+
     apiTrashbin:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiTrashbin'
@@ -113,6 +151,16 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
         - TrashbinContext:
+
+    apiVersions:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiVersions'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - ChecksumContext:
+        - FilesVersionsContext:
 
     apiWebdavLocks:
       paths:
@@ -184,6 +232,15 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+
+    cliMain:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/cliMain'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
         - OccContext:
 

--- a/tests/acceptance/config/ldap-users.ldif
+++ b/tests/acceptance/config/ldap-users.ldif
@@ -79,6 +79,29 @@ objectclass: top
 objectclass: organizationalUnit
 ou: TestUsers
 
+# Additional groups for core tests on ldap users
+dn: cn=hash#group,ou=TestGroups,dc=owncloud,dc=com
+cn: hash#group
+memberuid: user0
+memberuid: user2
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
+dn: cn=ordinary-group,ou=TestGroups,dc=owncloud,dc=com
+cn: ordinary-group
+memberuid: user1
+memberuid: user2
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
+dn: cn=group-3,ou=TestGroups,dc=owncloud,dc=com
+cn: group-3
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
 dn: uid=regularuser,ou=TestUsers,dc=owncloud,dc=com
 cn: Regular User
 sn: User


### PR DESCRIPTION
Related issue #354
Add all remaining core test suites for testing in drone

Requires **https://github.com/owncloud/core/pull/34340** in the QA tarball