### PR TITLE
Sort test suites alphabetically for LDAP and core

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1069,17 +1069,6 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiMetadataApps
-
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharees
 
     - TEST_SUITE: acceptance
@@ -1269,17 +1258,6 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiMetadataApps
-
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
-      OC_VERSION: daily-stable10-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharees
 
     - TEST_SUITE: acceptance
@@ -1459,17 +1437,6 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiMain
-
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
-      OC_VERSION: daily-stable10-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 5.6
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiMetadataApps
 
     - TEST_SUITE: acceptance
       TEST_SOURCE: core-api

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -85,14 +85,6 @@ default:
         - CardDavContext:
         - CalDavContext:
 
-    apiMetadataApps:
-      paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/apiMetadataApps'
-      context: *common_ldap_suite_context
-      contexts:
-        - UserLdapGeneralContext:
-        - FeatureContext: *common_feature_context_params
-
     apiSharees:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiSharees'

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -44,6 +44,16 @@ default:
         - FeatureContext: *common_feature_context_params
         - CapabilitiesContext:
 
+    apiComments:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiComments'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - CommentsContext:
+        - WebDavPropertiesContext:
+
     apiFavorites:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiFavorites'
@@ -62,16 +72,6 @@ default:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
         - FederationContext:
-        - WebDavPropertiesContext:
-
-    apiComments:
-      paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/apiComments'
-      context: *common_ldap_suite_context
-      contexts:
-        - UserLdapGeneralContext:
-        - FeatureContext: *common_feature_context_params
-        - CommentsContext:
         - WebDavPropertiesContext:
 
     apiMain:
@@ -215,6 +215,15 @@ default:
         - PublicWebDavContext:
 
 
+    cliMain:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/cliMain'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - OccContext:
+
     cliTrashbin:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/cliTrashbin'
@@ -235,29 +244,37 @@ default:
         - FeatureContext: *common_feature_context_params
         - OccContext:
 
-    cliMain:
+    apiUserLDAPConnection:
       paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/cliMain'
-      context: *common_ldap_suite_context
-      contexts:
-        - UserLdapGeneralContext:
-        - FeatureContext: *common_feature_context_params
-        - OccContext:
-
-    webUIUserLDAP:
-      paths:
-        - '%paths.base%/../features/webUIUserLDAP'
+        - '%paths.base%/../features/apiUserLDAPConnection'
       context: *common_ldap_suite_context
       contexts:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:
         - FeatureContext: *common_feature_context_params
-        - WebUIGeneralContext:
-        - WebUILoginContext:
-        - WebUIUserContext:
-        - WebUISharingContext:
-        - WebUIFilesContext:
+        - LoggingContext:
+
+    apiUserLDAPSharing:
+      paths:
+        - %paths.base%/../features/apiUserLDAPSharing
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - UserLdapUsersContext:
         - OccContext:
+        - FeatureContext: *common_feature_context_params
+
+    cliProvisioning:
+      paths:
+        - '%paths.base%/../features/cliProvisioning'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - UserLdapUsersContext:
+        - FeatureContext: *common_feature_context_params
+        - EmailContext:
+        - OccContext:
+        - OccUsersGroupsContext:
 
     webUIProvisioning:
       paths:
@@ -274,37 +291,20 @@ default:
         - WebUIFilesContext:
         - WebUINotificationsContext:
 
-    apiUserLDAPSharing:
+    webUIUserLDAP:
       paths:
-        - %paths.base%/../features/apiUserLDAPSharing
+        - '%paths.base%/../features/webUIUserLDAP'
       context: *common_ldap_suite_context
       contexts:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:
+        - FeatureContext: *common_feature_context_params
+        - WebUIGeneralContext:
+        - WebUILoginContext:
+        - WebUIUserContext:
+        - WebUISharingContext:
+        - WebUIFilesContext:
         - OccContext:
-        - FeatureContext: *common_feature_context_params
-
-    apiUserLDAPConnection:
-      paths:
-        - '%paths.base%/../features/apiUserLDAPConnection'
-      context: *common_ldap_suite_context
-      contexts:
-        - UserLdapGeneralContext:
-        - UserLdapUsersContext:
-        - FeatureContext: *common_feature_context_params
-        - LoggingContext:
-
-    cliProvisioning:
-      paths:
-        - '%paths.base%/../features/cliProvisioning'
-      context: *common_ldap_suite_context
-      contexts:
-        - UserLdapGeneralContext:
-        - UserLdapUsersContext:
-        - FeatureContext: *common_feature_context_params
-        - EmailContext:
-        - OccContext:
-        - OccUsersGroupsContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:


### PR DESCRIPTION
1) Sort test suites alphabetically for LDAP and core o make this a bit easier for people to check/review in future.
2) Remove non-existent core suite ``apiMetadataApps`` - that suite no longer exists (some time ago). The drone job does run and finds 0 test scenarios.
https://drone.owncloud.com/owncloud/user_ldap/1068/752
```
Running apiMetadataApps tests tagged ~@skipWhenTestingRemoteSystems&&~@skipOnOcV11&&~@skipOnOcV11.0&&~@skipOnOcV11.0.0&&@TestAlsoOnExternalUserBackend&&~@skipOnLDAP&&~@skip&&@api 
No scenarios
No steps
0m1.35s (12.58Mb)
Information: no matching scenarios were found.
runsh: Exit code of main run: 0
```
