### PR TITLE
Remove wrongly-named WebUIUsersContext

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -183,8 +183,8 @@ default:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
-        - SearchContext:
         - PublicWebDavContext:
+        - SearchContext:
 
     apiWebdavProperties:
       paths:
@@ -276,11 +276,11 @@ default:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:
         - FeatureContext: *common_feature_context_params
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIUserContext:
-        - WebUIFilesContext:
         - WebUINotificationsContext:
+        - WebUIUserContext:
 
     webUIUserLDAP:
       paths:
@@ -290,12 +290,12 @@ default:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
+        - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:
-        - WebUIUserContext:
         - WebUISharingContext:
-        - WebUIFilesContext:
-        - OccContext:
+        - WebUIUserContext:
 
   extensions:
       jarnaiz\JUnitFormatter\JUnitFormatterExtension:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -279,7 +279,6 @@ default:
         - WebUIGeneralContext:
         - WebUILoginContext:
         - WebUIUserContext:
-        - WebUIUsersContext:
         - WebUIFilesContext:
         - WebUINotificationsContext:
 


### PR DESCRIPTION
When running webUI acceptance tests locally, ``behat`` told me that it did not know about ``WebUIUsersContext``. That is true, because that context in core is called ``WebUIUserContext``

I have no idea why ``behat`` does not complain about this in drone. Anyway the steps in ``WebUIUserContext`` are not needed anyway.

While touching this, sort the contexts so it is easier to look through the list.