### PR TITLE
Config to json

### DIFF
--- a/appinfo/Migrations/Version20190315192717.php
+++ b/appinfo/Migrations/Version20190315192717.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * @author Viktar Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\User_LDAP\Migrations;
+
+use OCA\User_LDAP\Configuration;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IConfig;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\ISimpleMigration;
+
+/**
+ * Migrate configs that are split across records
+ * into a single json-encoded configuration
+ */
+class Version20190315192717 implements ISimpleMigration {
+	const REFERENCE_KEY = 'ldap_configuration_active';
+
+	/**
+	 * @var array - known DB configkeys and their defaults
+	 */
+	private $knownLegacyKeys = [
+		'has_memberof_filter_support' => 0,
+		'home_folder_naming_rule' => '',
+		'last_jpegPhoto_lookup' => 0,
+		'ldap_agent_password' => '',
+		'ldap_attributes_for_group_search' => '',
+		'ldap_attributes_for_user_search' => '',
+		'ldap_backup_host' => '',
+		'ldap_backup_port' => '',
+		'ldap_base' => '',
+		'ldap_base_groups' => '',
+		'ldap_base_users' => '',
+		'ldap_cache_ttl' => 600,
+		'ldap_configuration_active' => 0,
+		'ldap_display_name' => 'displayName',
+		'ldap_dn'  => '',
+		'ldap_dynamic_group_member_url'  => '',
+		'ldap_email_attr'  => '',
+		'ldap_experienced_admin'  => 0,
+		'ldap_expert_username_attr'  => '',
+		'ldap_expert_uuid_group_attr' => '',
+		'ldap_expert_uuid_user_attr' => '',
+		'ldap_group_display_name' => 'cn',
+		'ldap_group_filter'  => '',
+		'ldap_group_filter_mode' => 0,
+		'ldap_group_member_assoc_attribute'  => 'uniqueMember',
+		'ldap_groupfilter_groups'  => '',
+		'ldap_groupfilter_objectclass'  => '',
+		'ldap_host'  => '',
+		'ldap_login_filter'  => '',
+		'ldap_login_filter_mode' => 0,
+		'ldap_loginfilter_attributes' => '',
+		'ldap_loginfilter_email'  => 0,
+		'ldap_loginfilter_username' => 1,
+		'ldap_nested_groups' => 0,
+		'ldap_network_timeout' => 2,
+		'ldap_override_main_server' => '',
+		'ldap_paging_size' => 500,
+		'ldap_port' => '',
+		'ldap_quota_attr' => '',
+		'ldap_quota_def' => '',
+		'ldap_tls' => 0,
+		'ldap_turn_off_cert_check' => 0,
+		'ldap_user_display_name_2' => '',
+		'ldap_user_filter_mode' => 0,
+		'ldap_user_name' => 'samaccountname',
+		'ldap_userfilter_groups' => '',
+		'ldap_userfilter_objectclass' => '',
+		'ldap_userlist_filter' => '',
+		'use_memberof_to_detect_membership' => 1
+	];
+
+	private $translations = [
+		'ldap_host'                         => 'ldapHost',
+		'ldap_port'                         => 'ldapPort',
+		'ldap_backup_host'                  => 'ldapBackupHost',
+		'ldap_backup_port'                  => 'ldapBackupPort',
+		'ldap_override_main_server'         => 'ldapOverrideMainServer',
+		'ldap_dn'                           => 'ldapAgentName',
+		'ldap_agent_password'               => 'ldapAgentPassword',
+		'ldap_base'                         => 'ldapBase',
+		'ldap_base_users'                   => 'ldapBaseUsers',
+		'ldap_base_groups'                  => 'ldapBaseGroups',
+		'ldap_userfilter_objectclass'       => 'ldapUserFilterObjectclass',
+		'ldap_userfilter_groups'            => 'ldapUserFilterGroups',
+		'ldap_userlist_filter'              => 'ldapUserFilter',
+		'ldap_user_filter_mode'             => 'ldapUserFilterMode',
+		'ldap_login_filter'                 => 'ldapLoginFilter',
+		'ldap_login_filter_mode'            => 'ldapLoginFilterMode',
+		'ldap_loginfilter_email'            => 'ldapLoginFilterEmail',
+		'ldap_loginfilter_username'         => 'ldapLoginFilterUsername',
+		'ldap_loginfilter_attributes'       => 'ldapLoginFilterAttributes',
+		'ldap_group_filter'                 => 'ldapGroupFilter',
+		'ldap_group_filter_mode'            => 'ldapGroupFilterMode',
+		'ldap_groupfilter_objectclass'      => 'ldapGroupFilterObjectclass',
+		'ldap_groupfilter_groups'           => 'ldapGroupFilterGroups',
+		'ldap_user_name'                    => 'ldapUserName',
+		'ldap_display_name'                 => 'ldapUserDisplayName',
+		'ldap_user_display_name_2'          => 'ldapUserDisplayName2',
+		'ldap_group_display_name'           => 'ldapGroupDisplayName',
+		'ldap_tls'                          => 'ldapTLS',
+		'ldap_quota_def'                    => 'ldapQuotaDefault',
+		'ldap_quota_attr'                   => 'ldapQuotaAttribute',
+		'ldap_email_attr'                   => 'ldapEmailAttribute',
+		'ldap_group_member_assoc_attribute' => 'ldapGroupMemberAssocAttr',
+		'ldap_cache_ttl'                    => 'ldapCacheTTL',
+		'ldap_network_timeout'              => 'ldapNetworkTimeout',
+		'home_folder_naming_rule'           => 'homeFolderNamingRule',
+		'ldap_turn_off_cert_check'          => 'turnOffCertCheck',
+		'ldap_configuration_active'         => 'ldapConfigurationActive',
+		'ldap_attributes_for_user_search'   => 'ldapAttributesForUserSearch',
+		'ldap_attributes_for_group_search'  => 'ldapAttributesForGroupSearch',
+		'ldap_expert_username_attr'         => 'ldapExpertUsernameAttr',
+		'ldap_expert_uuid_user_attr'        => 'ldapExpertUUIDUserAttr',
+		'ldap_expert_uuid_group_attr'       => 'ldapExpertUUIDGroupAttr',
+		'has_memberof_filter_support'       => 'hasMemberOfFilterSupport',
+		'use_memberof_to_detect_membership' => 'useMemberOfToDetectMembership',
+		'last_jpegPhoto_lookup'             => 'lastJpegPhotoLookup',
+		'ldap_nested_groups'                => 'ldapNestedGroups',
+		'ldap_paging_size'                  => 'ldapPagingSize',
+		'ldap_experienced_admin'            => 'ldapExperiencedAdmin',
+		'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
+	];
+
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $dbConnection;
+
+	/**
+	 * Version20190315192717 constructor.
+	 *
+	 * @param IConfig $config
+	 * @param IDBConnection $dbConnection
+	 */
+	public function __construct(IConfig $config, IDBConnection $dbConnection) {
+		$this->config = $config;
+		$this->dbConnection = $dbConnection;
+	}
+
+	/**
+	 * Json encode all existing ldap server configurations
+	 *
+	 * @param IOutput $out
+	 */
+	public function run(IOutput $out) {
+		$configPrefixes = $this->getLegacyConfigPrefixes();
+		$out->info('Converting LDAP configurations');
+		$out->startProgress(\count($configPrefixes));
+		$converted = 0;
+		foreach ($configPrefixes as $prefix) {
+			$config = $this->getTranslatedLegacyConfig($prefix);
+			$this->convertConfig($prefix, $config);
+			$converted++;
+			$out->advance($converted, $prefix);
+			$this->deleteLegacyConfig($prefix);
+		}
+		$out->finishProgress();
+		$out->info('');
+		$out->info('Done');
+	}
+
+	/**
+	 * Get all legacy configuration prefixes  by enumerating
+	 * whateverldap_configuration_active config keys in appconfig table
+	 *
+	 * @return string[]
+	 */
+	protected function getLegacyConfigPrefixes() {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->selectDistinct('configkey')
+			->from('appconfig')
+			->where(
+				$qb->expr()->eq('appid', $qb->expr()->literal('user_ldap'))
+			)
+			->andWhere(
+				$qb->expr()->like('configkey', $qb->expr()->literal('%' . self::REFERENCE_KEY))
+			);
+		$result = $qb->execute();
+		$configs = $result->fetchAll();
+		$prefixes = [];
+		foreach ($configs as $config) {
+			$len = \strlen($config['configkey']) - \strlen(self::REFERENCE_KEY);
+			$prefixes[] = \substr($config['configkey'], 0, $len);
+		}
+		return $prefixes;
+	}
+
+	/**
+	 * Collects all known fields into a single array
+	 *
+	 * @param string $prefix
+	 *
+	 * @return array
+	 */
+	protected function getTranslatedLegacyConfig($prefix) {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->select('configkey', 'configvalue')
+			->from('appconfig')
+			->where(
+				$qb->expr()->eq('appid', $qb->expr()->literal('user_ldap'))
+			)
+			->andWhere(
+				$qb->expr()->in(
+					'configkey',
+					$qb->createParameter('keys'),
+					IQueryBuilder::PARAM_STR_ARRAY
+				)
+			)
+			->setParameter('keys', $this->getPrefixedLegacyKeys($prefix), IQueryBuilder::PARAM_STR_ARRAY);
+
+		$result = $qb->execute();
+		$configValues = $result->fetchAll();
+
+		$current = [];
+		foreach ($configValues as $row) {
+			// if there is a prefix we need to remove its first occurrence in key
+			$key = $prefix === ''
+				? $row['configkey']
+				: \implode('', \explode($prefix, $row['configkey'], 2));
+			$translatedKey = $this->translations[$key];
+			$current[$translatedKey] = $row['configvalue'];
+		}
+		\ksort($this->translations);
+		\ksort($this->knownLegacyKeys);
+		$defaults = \array_combine(
+			\array_values($this->translations),
+			\array_values($this->knownLegacyKeys)
+		);
+		return \array_merge($defaults, $current);
+	}
+
+	/**
+	 * Store config as json
+	 *
+	 * @param string $prefix
+	 * @param array $legacyConfig
+	 */
+	protected function convertConfig($prefix, $legacyConfig) {
+		$this->config->setAppValue(
+			'user_ldap',
+			Configuration::CONFIG_PREFIX . $prefix,
+			\json_encode($legacyConfig)
+		);
+	}
+
+	/**
+	 * Deletes a given legacy LDAP/AD server configuration.
+	 *
+	 * @param string $prefix the configuration prefix of the config to delete
+	 *
+	 * @return bool true on success, false otherwise
+	 */
+	public function deleteLegacyConfig($prefix) {
+		$qb = $this->dbConnection->getQueryBuilder();
+		$qb->delete('appconfig')
+			->where(
+				$qb->expr()->eq('appid', $qb->expr()->literal('user_ldap'))
+			)
+			->andWhere(
+				$qb->expr()->in(
+					'configkey',
+					$qb->createParameter('keys'),
+					IQueryBuilder::PARAM_STR_ARRAY
+				)
+			)
+			->setParameter('keys', $this->getPrefixedLegacyKeys($prefix), IQueryBuilder::PARAM_STR_ARRAY);
+		$qb->execute();
+		return true;
+	}
+
+	/**
+	 * Get all possible configkey names prefixed with a given string
+	 *
+	 * @param string $prefix
+	 *
+	 * @return array
+	 */
+	protected function getPrefixedLegacyKeys($prefix) {
+		$keys = \array_keys($this->knownLegacyKeys);
+		\array_walk(
+			$keys,
+			function (&$key) use ($prefix) {
+				$key = "{$prefix}{$key}";
+			}
+		);
+		return $keys;
+	}
+}

--- a/appinfo/Migrations/Version20190315192717.php
+++ b/appinfo/Migrations/Version20190315192717.php
@@ -175,7 +175,7 @@ class Version20190315192717 implements ISimpleMigration {
 		$converted = 0;
 		foreach ($configPrefixes as $prefix) {
 			$config = $this->getTranslatedLegacyConfig($prefix);
-			$this->convertConfig($prefix, $config);
+			$this->storeConfig($prefix, $config);
 			$converted++;
 			$out->advance($converted, $prefix);
 			$this->deleteLegacyConfig($prefix);
@@ -191,7 +191,7 @@ class Version20190315192717 implements ISimpleMigration {
 	 *
 	 * @return string[]
 	 */
-	protected function getLegacyConfigPrefixes() {
+	private function getLegacyConfigPrefixes() {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->selectDistinct('configkey')
 			->from('appconfig')
@@ -218,7 +218,7 @@ class Version20190315192717 implements ISimpleMigration {
 	 *
 	 * @return array
 	 */
-	protected function getTranslatedLegacyConfig($prefix) {
+	private function getTranslatedLegacyConfig($prefix) {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->select('configkey', 'configvalue')
 			->from('appconfig')
@@ -246,26 +246,26 @@ class Version20190315192717 implements ISimpleMigration {
 			$translatedKey = $this->translations[$key];
 			$current[$translatedKey] = $row['configvalue'];
 		}
-		\ksort($this->translations);
-		\ksort($this->knownLegacyKeys);
-		$defaults = \array_combine(
-			\array_values($this->translations),
-			\array_values($this->knownLegacyKeys)
-		);
-		return \array_merge($defaults, $current);
+		foreach ($this->translations as $legacyKey => $newKey) {
+			if (!isset($current[$newKey])) {
+				$current[$newKey] = $this->knownLegacyKeys[$legacyKey];
+			}
+		}
+
+		return $current;
 	}
 
 	/**
 	 * Store config as json
 	 *
 	 * @param string $prefix
-	 * @param array $legacyConfig
+	 * @param array $configData
 	 */
-	protected function convertConfig($prefix, $legacyConfig) {
+	private function storeConfig($prefix, $configData) {
 		$this->config->setAppValue(
 			'user_ldap',
 			Configuration::CONFIG_PREFIX . $prefix,
-			\json_encode($legacyConfig)
+			\json_encode($configData)
 		);
 	}
 
@@ -274,9 +274,8 @@ class Version20190315192717 implements ISimpleMigration {
 	 *
 	 * @param string $prefix the configuration prefix of the config to delete
 	 *
-	 * @return bool true on success, false otherwise
 	 */
-	public function deleteLegacyConfig($prefix) {
+	private function deleteLegacyConfig($prefix) {
 		$qb = $this->dbConnection->getQueryBuilder();
 		$qb->delete('appconfig')
 			->where(
@@ -291,7 +290,6 @@ class Version20190315192717 implements ISimpleMigration {
 			)
 			->setParameter('keys', $this->getPrefixedLegacyKeys($prefix), IQueryBuilder::PARAM_STR_ARRAY);
 		$qb->execute();
-		return true;
 	}
 
 	/**
@@ -301,14 +299,12 @@ class Version20190315192717 implements ISimpleMigration {
 	 *
 	 * @return array
 	 */
-	protected function getPrefixedLegacyKeys($prefix) {
-		$keys = \array_keys($this->knownLegacyKeys);
-		\array_walk(
-			$keys,
-			function (&$key) use ($prefix) {
-				$key = "{$prefix}{$key}";
-			}
-		);
-		return $keys;
+	private function getPrefixedLegacyKeys($prefix) {
+		$prefixed = [];
+		foreach ($this->knownLegacyKeys as $key => $value) {
+			$prefixedKey = "{$prefix}{$key}";
+			$prefixed[] = $prefixedKey;
+		}
+		return $prefixed;
 	}
 }

--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -29,7 +29,6 @@
 namespace OCA\User_LDAP;
 
 class Helper {
-
 	/**
 	 * FIXME use public AppConfig API
 	 * returns prefixes for each saved LDAP/AD server configuration.
@@ -52,32 +51,16 @@ class Helper {
 	 *
 	 */
 	public function getServerConfigurationPrefixes($activeConfigurations = false) {
-		$referenceConfigkey = 'ldap_configuration_active';
-
-		$sql = '
-			SELECT DISTINCT `configkey`
-			FROM `*PREFIX*appconfig`
-			WHERE `appid` = \'user_ldap\'
-				AND `configkey` LIKE ?
-		';
-
-		if ($activeConfigurations) {
-			if (\OC::$server->getConfig()->getSystemValue('dbtype', 'sqlite') === 'oci') {
-				//FIXME oracle hack: need to explicitly cast CLOB to CHAR for comparison
-				$sql .= ' AND to_char(`configvalue`)=\'1\'';
-			} else {
-				$sql .= ' AND `configvalue` = \'1\'';
-			}
-		}
-
-		$stmt = \OCP\DB::prepare($sql);
-
-		$serverConfigs = $stmt->execute(['%'.$referenceConfigkey])->fetchAll();
+		$serverConfigs = $this->getAllConfigurations();
 		$prefixes = [];
-
 		foreach ($serverConfigs as $serverConfig) {
-			$len = \strlen($serverConfig['configkey']) - \strlen($referenceConfigkey);
-			$prefixes[] = \substr($serverConfig['configkey'], 0, $len);
+			if ($activeConfigurations === true) {
+				$c = \json_decode($serverConfig['configvalue'], true);
+				if (\intval($c['ldapConfigurationActive']) !== 1) {
+					continue;
+				}
+			}
+			$prefixes[] = $this->stripPrefix($serverConfig['configkey']);
 		}
 
 		return $prefixes;
@@ -90,22 +73,12 @@ class Helper {
 	 *
 	 */
 	public function getServerConfigurationHosts() {
-		$referenceConfigkey = 'ldap_host';
-
-		$query = '
-			SELECT DISTINCT `configkey`, `configvalue`
-			FROM `*PREFIX*appconfig`
-			WHERE `appid` = \'user_ldap\'
-				AND `configkey` LIKE ?
-		';
-		$query = \OCP\DB::prepare($query);
-		$configHosts = $query->execute(['%'.$referenceConfigkey])->fetchAll();
+		$serverConfigs = $this->getAllConfigurations();
 		$result = [];
-
-		foreach ($configHosts as $configHost) {
-			$len = \strlen($configHost['configkey']) - \strlen($referenceConfigkey);
-			$prefix = \substr($configHost['configkey'], 0, $len);
-			$result[$prefix] = $configHost['configvalue'];
+		foreach ($serverConfigs as $serverConfig) {
+			$prefix = $this->stripPrefix($serverConfig['configkey']);
+			$c = \json_decode($serverConfig['configvalue'], true);
+			$result[$prefix] = $c['ldapHost'];
 		}
 
 		return $result;
@@ -120,27 +93,24 @@ class Helper {
 		if (!\in_array($prefix, self::getServerConfigurationPrefixes())) {
 			return false;
 		}
-
-		$saveOtherConfigurations = '';
-		if (empty($prefix)) {
-			$saveOtherConfigurations = 'AND `configkey` NOT LIKE \'s%\'';
-		}
-
-		$query = \OCP\DB::prepare('
-			DELETE
-			FROM `*PREFIX*appconfig`
-			WHERE `configkey` LIKE ?
-				'.$saveOtherConfigurations.'
-				AND `appid` = \'user_ldap\'
-				AND `configkey` NOT IN (\'enabled\', \'installed_version\', \'types\', \'bgjUpdateGroupsLastRun\')
-		');
-		$delRows = $query->execute([$prefix.'%']);
-
-		if (\OCP\DB::isError($delRows)) {
+		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		try {
+			$qb->delete('appconfig')
+				->where(
+					$qb->expr()->eq('appid', $qb->expr()->literal('user_ldap'))
+				)
+				->andWhere(
+					$qb->expr()->like(
+						'configkey',
+						$qb->expr()->literal(Configuration::CONFIG_PREFIX . $prefix)
+					)
+				);
+			$result = $qb->execute();
+		} catch (\Exception $e) {
 			return false;
 		}
 
-		if ($delRows === 0) {
+		if ($result->rowCount() === 0) {
 			return false;
 		}
 
@@ -149,18 +119,17 @@ class Helper {
 
 	/**
 	 * checks whether there is one or more disabled LDAP configurations
-	 * @throws \Exception
 	 * @return bool
 	 */
 	public function haveDisabledConfigurations() {
-		$all = $this->getServerConfigurationPrefixes(false);
-		$active = $this->getServerConfigurationPrefixes(true);
-
-		if (!\is_array($all) || !\is_array($active)) {
-			throw new \Exception('Unexpected Return Value');
+		$all = $this->getAllConfigurations();
+		foreach ($all as $serverConfig) {
+			$c = \json_decode($serverConfig['configvalue'], true);
+			if (\intval($c['ldapConfigurationActive']) !== 1) {
+				return true;
+			}
 		}
-
-		return \count($all) !== \count($active) || \count($all) === 0;
+		return \count($all) === 0;
 	}
 
 	/**
@@ -332,5 +301,27 @@ class Helper {
 		$dn = \str_replace(\array_keys($replacements), \array_values($replacements), $dn);
 
 		return $dn;
+	}
+
+	protected function getAllConfigurations() {
+		$qb = \OC::$server->getDatabaseConnection()->getQueryBuilder();
+		$qb->select('configkey', 'configvalue')
+			->from('appconfig')
+			->where(
+				$qb->expr()->eq('appid', $qb->expr()->literal('user_ldap'))
+			)
+			->andWhere(
+				$qb->expr()->like('configkey', $qb->expr()->literal(Configuration::CONFIG_PREFIX . '%'))
+			);
+
+		$result = $qb->execute();
+		return $result->fetchAll();
+	}
+
+	protected function stripPrefix($configurationId) {
+		return \implode(
+			'',
+			\explode(Configuration::CONFIG_PREFIX, $configurationId, 2)
+		);
 	}
 }

--- a/tests/unit/Controller/ConfigurationControllerTest.php
+++ b/tests/unit/Controller/ConfigurationControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace OCA\User_LDAP\Controller;
 
+use OCA\User_LDAP\Configuration;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCP\AppFramework\Http\DataResponse;
@@ -82,7 +83,7 @@ class ConfigurationControllerTest extends TestCase {
 
 		$this->config->expects($this->any())
 			->method('setAppValue')
-			->with('user_ldap', $this->stringStartsWith('tcr'), $this->anything());
+			->with('user_ldap', Configuration::CONFIG_PREFIX . 'tcr', $this->anything());
 
 		$result = $this->controller->create();
 
@@ -148,18 +149,15 @@ class ConfigurationControllerTest extends TestCase {
 	}
 
 	public function testRead() {
+		$config = $this->getLdapConfig(
+			[
+				'ldapHost' => 'example.org',
+				'ldapAgentPassword' => \base64_encode('secret')
+			]
+		);
 		$this->config->expects($this->any())
 			->method('getAppValue')
-			->will($this->returnCallback(function ($app, $key, $default) {
-				switch ($key) {
-					case 't01ldap_host':
-						return 'example.org';
-					case 't01ldap_agent_password':
-						return  \base64_encode('secret');
-					default:
-						return $default;
-				}
-			}));
+			->willReturn(\json_encode($config));
 
 		$result = $this->controller->read('t01');
 
@@ -175,34 +173,23 @@ class ConfigurationControllerTest extends TestCase {
 	}
 
 	public function testTest() {
-
 		// use valid looking config to pass critical validation
+		$config = $this->getLdapConfig(
+			[
+				'ldapHost' => 'example.org',
+				'ldapPort' => '389',
+				'ldapDisplayName' => 'displayName',
+				'ldapGroupDisplayName' => 'cn',
+				'ldapLoginFilter' => '(uid=%uid)',
+				'ldapConfigurationActive' => 1,
+				'ldapAgentName' => 'cn=admin',
+				'ldapBase' => 'dc=example,dc=org',
+				'ldapAgentPassword' => \base64_encode('secret')
+			]
+		);
 		$this->config->expects($this->any())
 			->method('getAppValue')
-			->will($this->returnCallback(function ($app, $key, $default) {
-				switch ($key) {
-					case 't01ldap_host':
-						return 'example.org';
-					case 't01ldap_port':
-						return '389';
-					case 't01ldap_display_name':
-						return 'displayName';
-					case 't01ldap_group_display_name':
-						return 'cn';
-					case 't01ldap_login_filter':
-						return '(uid=%uid)';
-					case 't01ldap_configuration_active':
-						return '1';
-					case 't01ldap_dn':
-						return  'cn=admin';
-					case 't01ldap_base':
-						return  'dc=example,dc=org';
-					case 't01ldap_agent_password':
-						return  \base64_encode('secret');
-					default:
-						return $default;
-				}
-			}));
+			->willReturn(\json_encode($config));
 
 		$this->ldap->expects($this->any())
 			->method('areLDAPFunctionsAvailable')
@@ -245,5 +232,13 @@ class ConfigurationControllerTest extends TestCase {
 		$this->assertInstanceOf(DataResponse::class, $result);
 		$data = $result->getData();
 		$this->assertArraySubset(['status' => 'error'], $data, true);
+	}
+
+	protected function getLdapConfig($values) {
+		$config = \array_merge(
+			(new Configuration($this->config, ''))->getDefaults(),
+			$values
+		);
+		return $config;
 	}
 }


### PR DESCRIPTION
**Contains a migration - needs minor version bump for the app**

Make transition to new Wizard easier by
- [x] migrating to json-encoded server config in advance.
- [x] Translate server configuration from underscore to pascalCase only when dealing with frontend (before this PR it was done for the database too)

Before:
```
select configkey, configvalue from oc_appconfig where appid='user_ldap' and configkey  like 's01%';
+--------------------------------------+----------------+
| configkey                            | configvalue    |
+--------------------------------------+----------------+
| s01has_memberof_filter_support       | 0              |
| s01home_folder_naming_rule           |                |
| s01last_jpegPhoto_lookup             | 0              |
| s01ldap_agent_password               |                |
| s01ldap_attributes_for_group_search  |                |
| s01ldap_attributes_for_user_search   |                |
| s01ldap_backup_host                  |                |
| s01ldap_backup_port                  |                |
| s01ldap_base                         |                |
| s01ldap_base_groups                  |                |
| s01ldap_base_users                   |                |
| s01ldap_cache_ttl                    | 600            |
| s01ldap_configuration_active         | 0              |
| s01ldap_display_name                 | displayName    |
| s01ldap_dn                           |                |
| s01ldap_dynamic_group_member_url     |                |
| s01ldap_email_attr                   |                |
| s01ldap_experienced_admin            | 0              |
| s01ldap_expert_username_attr         |                |
| s01ldap_expert_uuid_group_attr       |                |
| s01ldap_expert_uuid_user_attr        |                |
| s01ldap_group_display_name           | cn             |
| s01ldap_group_filter                 |                |
| s01ldap_group_filter_mode            | 0              |
| s01ldap_group_member_assoc_attribute | uniqueMember   |
| s01ldap_groupfilter_groups           |                |
| s01ldap_groupfilter_objectclass      |                |
| s01ldap_host                         |                |
| s01ldap_login_filter                 |                |
| s01ldap_login_filter_mode            | 0              |
| s01ldap_loginfilter_attributes       |                |
| s01ldap_loginfilter_email            | 0              |
| s01ldap_loginfilter_username         | 1              |
| s01ldap_nested_groups                | 0              |
| s01ldap_network_timeout              | 2              |
| s01ldap_override_main_server         |                |
| s01ldap_paging_size                  | 500            |
| s01ldap_port                         |                |
| s01ldap_quota_attr                   |                |
| s01ldap_quota_def                    |                |
| s01ldap_tls                          | 0              |
| s01ldap_turn_off_cert_check          | 0              |
| s01ldap_user_display_name_2          |                |
| s01ldap_user_filter_mode             | 0              |
| s01ldap_user_name                    | samaccountname |
| s01ldap_userfilter_groups            |                |
| s01ldap_userfilter_objectclass       |                |
| s01ldap_userlist_filter              |                |
| s01use_memberof_to_detect_membership | 1              |
+--------------------------------------+----------------+
```


After
```
select configkey, configvalue from oc_appconfig where appid='user_ldap' and configkey  = 'conn-s01';
| conn-s01  | {"hasMemberOfFilterSupport":"0","homeFolderNamingRule":"","lastJpegPhotoLookup":"0","ldapAgentPassword":"","ldapAttributesForGroupSearch":"","ldapAttributesForUserSearch":"","ldapBackupHost":"","ldapBackupPort":"","ldapBase":"","ldapBaseGroups":"","ldapBaseUsers":"","ldapCacheTTL":"600","ldapConfigurationActive":"0","ldapUserDisplayName":"displayName","ldapAgentName":"","ldapDynamicGroupMemberURL":"","ldapEmailAttribute":"","ldapExperiencedAdmin":"0","ldapExpertUsernameAttr":"","ldapExpertUUIDGroupAttr":"","ldapExpertUUIDUserAttr":"","ldapGroupDisplayName":"cn","ldapGroupFilter":"","ldapGroupFilterMode":"0","ldapGroupMemberAssocAttr":"uniqueMember","ldapGroupFilterGroups":"","ldapGroupFilterObjectclass":"","ldapHost":"","ldapLoginFilter":"","ldapLoginFilterMode":"0","ldapLoginFilterAttributes":"","ldapLoginFilterEmail":"0","ldapLoginFilterUsername":"1","ldapNestedGroups":"0","ldapNetworkTimeout":"2","ldapOverrideMainServer":"","ldapPagingSize":"500","ldapPort":"","ldapQuotaAttribute":"","ldapQuotaDefault":"","ldapTLS":"0","turnOffCertCheck":"0","ldapUserDisplayName2":"","ldapUserFilterMode":"0","ldapUserName":"samaccountname","ldapUserFilterGroups":"","ldapUserFilterObjectclass":"","ldapUserFilter":"","useMemberOfToDetectMembership":"1"} |
```

Note: I tried to made the migration as independent as possible so the changes in app won't break it in future.