### PR TITLE
disable integrity check because of QA tarball issue

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -102,6 +102,7 @@ pipeline:
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
       - php occ log:manage --level 0
+      - php occ config:system:set --value true --type boolean integrity.check.disabled
     when:
       matrix:
         NEED_INSTALL_APP: true


### PR DESCRIPTION
Issue https://github.com/owncloud/core/issues/34787

disable integrity check during test runs

see other app changes ffor similar:
https://github.com/owncloud/user_management/pull/169
https://github.com/owncloud/password_policy/pull/213

to fix drone fails like:
https://drone.owncloud.com/owncloud/user_ldap/1293/395