### PR TITLE
Standardize CI scripts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -145,7 +145,33 @@ pipeline:
       matrix:
         NEED_SERVER: true
 
-  ldap-webui-acceptance-tests:
+  api-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - TEST_SERVER_URL=http://server
+      - TEST_EXTERNAL_USER_BACKENDS=true
+      - BEHAT_SUITE=${BEHAT_SUITE}
+    commands:
+      - make test-acceptance-api
+    when:
+      matrix:
+        TEST_SUITE: api-acceptance
+
+  cli-acceptance-tests:
+    image: owncloudci/php:${PHP_VERSION}
+    pull: true
+    environment:
+      - TEST_SERVER_URL=http://server
+      - TEST_EXTERNAL_USER_BACKENDS=true
+      - BEHAT_SUITE=${BEHAT_SUITE}
+    commands:
+      - make test-acceptance-cli
+    when:
+      matrix:
+        TEST_SUITE: cli-acceptance
+
+  webui-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -157,12 +183,12 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-      - make test-acceptance-ldap-webui
+      - make test-acceptance-webui
     when:
       matrix:
         TEST_SUITE: web-acceptance
 
-  ldap-cli-acceptance-tests:
+  core-api-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -170,13 +196,12 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-      - make test-acceptance-ldap-cli
+      - make test-acceptance-core-api
     when:
       matrix:
-        TEST_SOURCE: ldap
-        TEST_SUITE: cli-acceptance
+        TEST_SUITE: core-api-acceptance
 
-  ldap-api-acceptance-tests:
+  core-cli-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -184,13 +209,12 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
-      - make test-acceptance-ldap-api
+      - make test-acceptance-core-cli
     when:
       matrix:
-        TEST_SOURCE: ldap
-        TEST_SUITE: api-acceptance
+        TEST_SUITE: core-cli-acceptance
 
-  run-core-webui-tests:
+  core-webui-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
     environment:
@@ -203,36 +227,10 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=webUICore
     commands:
-      - make test-acceptance-webui
+      - make test-acceptance-core-webui
     when:
       matrix:
-        TEST_SOURCE: core-webUI
-
-  run-core-api-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - make test-acceptance-api
-    when:
-      matrix:
-        TEST_SOURCE: core-api
-
-  run-core-cli-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - make test-acceptance-cli
-    when:
-      matrix:
-        TEST_SOURCE: core-cli
+        TEST_SUITE: core-web-acceptance
 
   run-integration-tests:
     image: owncloudci/php:${PHP_VERSION}
@@ -508,7 +506,6 @@ matrix:
     # acceptance tests - ldap specific
     # with php 7.1 and core master
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: sqlite
       DB_NAME: owncloud
@@ -520,7 +517,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -532,7 +528,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -544,7 +539,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: sqlite
       DB_NAME: owncloud
@@ -557,7 +551,6 @@ matrix:
       NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -570,7 +563,6 @@ matrix:
       NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -583,7 +575,6 @@ matrix:
       NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: cli-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -594,7 +585,6 @@ matrix:
       BEHAT_SUITE: cliProvisioning
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -605,7 +595,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPConnection
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -616,7 +605,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPSharing
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -629,7 +617,6 @@ matrix:
     # acceptance tests - ldap specific
     # with php 7.2 and core master
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -641,7 +628,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -653,7 +639,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -666,7 +651,6 @@ matrix:
       NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -679,7 +663,6 @@ matrix:
       NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: cli-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -690,7 +673,6 @@ matrix:
       BEHAT_SUITE: cliProvisioning
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -701,7 +683,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPConnection
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -712,7 +693,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPSharing
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-master-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -725,7 +705,6 @@ matrix:
     # acceptance tests - ldap specific
     # with php 7.2 and core stable10
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -737,7 +716,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -749,7 +727,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -761,7 +738,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: cli-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -772,7 +748,6 @@ matrix:
       BEHAT_SUITE: cliProvisioning
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -783,7 +758,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPConnection
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -794,7 +768,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPSharing
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -807,7 +780,6 @@ matrix:
     # acceptance tests - ldap specific
     # with php 7.0 and core stable10
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -819,7 +791,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -831,7 +802,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: oci
       DB_NAME: XE
@@ -843,7 +813,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -855,7 +824,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: pgsql
       DB_NAME: owncloud
@@ -867,7 +835,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: web-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: oci
       DB_NAME: XE
@@ -879,7 +846,6 @@ matrix:
       NEED_SELENIUM: true
 
     - TEST_SUITE: cli-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -890,7 +856,6 @@ matrix:
       BEHAT_SUITE: cliProvisioning
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -901,7 +866,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPConnection
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -912,7 +876,6 @@ matrix:
       BEHAT_SUITE: apiUserLDAPSharing
 
     - TEST_SUITE: api-acceptance
-      TEST_SOURCE: ldap
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -923,8 +886,7 @@ matrix:
       BEHAT_SUITE: apiProvisioningLDAP
 
     # acceptance tests - UI tests from core
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-webUI
+    - TEST_SUITE: core-web-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -936,8 +898,7 @@ matrix:
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-webUI
+    - TEST_SUITE: core-web-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -951,8 +912,7 @@ matrix:
 
     #acceptance tests - CLI tests from core
     # with php 7.1 and core master
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-cli
+    - TEST_SUITE: core-cli-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -963,8 +923,7 @@ matrix:
       BEHAT_SUITE: cliTrashbin
 
     # with php 7.0 and core stable10
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-cli
+    - TEST_SUITE: core-cli-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -976,8 +935,7 @@ matrix:
 
     # acceptance tests - API tests from core
     # with php 7.1 and core master
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -987,8 +945,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiAuth
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -998,8 +955,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiCapabilities
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1009,8 +965,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiFavorites
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1020,8 +975,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiFederation
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1031,8 +985,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiComments
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1042,8 +995,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiMain
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1053,8 +1005,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharees
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1064,8 +1015,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareManagement
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1075,8 +1025,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareOperations
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1086,8 +1035,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharingNotifications
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1097,8 +1045,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTrashbin
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1108,8 +1055,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTags
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1119,8 +1065,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiVersions
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1130,8 +1075,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavLocks
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1141,8 +1085,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavMove
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1152,8 +1095,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavOperations
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1163,8 +1105,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavProperties
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1176,8 +1117,7 @@ matrix:
 
     # acceptance tests - API tests from core
     # with php 7.0 and core stable10
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1187,8 +1127,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiAuth
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1198,8 +1137,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiCapabilities
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1209,8 +1147,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiComments
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1220,8 +1157,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiFavorites
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1231,8 +1167,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiFederation
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1242,8 +1177,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiMain
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1253,8 +1187,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharees
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1264,8 +1197,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareManagement
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1275,8 +1207,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareOperations
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1286,8 +1217,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiSharingNotifications
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1297,8 +1227,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTags
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1308,8 +1237,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiTrashbin
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1319,8 +1247,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiVersions
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1330,8 +1257,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavLocks
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1341,8 +1267,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavMove
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1352,8 +1277,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavOperations
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud
@@ -1363,8 +1287,7 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavProperties
 
-    - TEST_SUITE: acceptance
-      TEST_SOURCE: core-api
+    - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa
       DB_TYPE: mysql
       DB_NAME: owncloud


### PR DESCRIPTION
Issue #330 

- [x] Set `composer_deps` and `composer_dev_deps` to nothing. 
- [x] Remove use of `composer_deps` and `composer_dev_deps`.
- [x] Set new `help` target and add help message
- [x] Remove `$(COMPOSER_BIN)` (doesnot work anyway due to PR #328 )
- [x] Refactor drone for testing core's acceptance and apps' acceptance, as done in `encryption`, i.e. do not make separate `test-acceptance-ldap`.
- [x] Remove use of `TEST_SOURCE`, use `TEST_SUITE`.
