### PR TITLE
Rename controller args and json keys

### DIFF
--- a/js/wizard/configModel.js
+++ b/js/wizard/configModel.js
@@ -62,7 +62,7 @@ OCA = OCA || {};
 
 			this.configID = configID;
 			var url = OC.generateUrl('apps/user_ldap/ajax/getConfiguration.php');
-			var params = OC.buildQueryString({ldap_serverconfig_chooser: configID});
+			var params = OC.buildQueryString({id: configID});
 			this.loadingConfig = true;
 			var model = this;
 			$.post(url, params, function (result) { model._processLoadConfig(model, result) });
@@ -96,7 +96,7 @@ OCA = OCA || {};
 		 */
 		deleteConfig: function(configID) {
 			var url = OC.generateUrl('apps/user_ldap/ajax/deleteConfiguration.php');
-			var params = OC.buildQueryString({ldap_serverconfig_chooser: configID});
+			var params = OC.buildQueryString({id: configID});
 			var model = this;
 			$.post(url, params, function (result) { model._processDeleteConfig(model, result, configID) });
 		},
@@ -173,7 +173,7 @@ OCA = OCA || {};
 			this._broadcast('setRequested', {});
 			var url = OC.generateUrl('apps/user_ldap/ajax/wizard.php');
 			var objParams = {
-				ldap_serverconfig_chooser: this.configID,
+				id: this.configID,
 				action: 'save',
 				cfgkey: key,
 				cfgval: value
@@ -344,7 +344,7 @@ OCA = OCA || {};
 		 */
 		requestConfigurationTest: function() {
 			var url = OC.generateUrl('apps/user_ldap/ajax/testConfiguration.php');
-			var params = OC.buildQueryString({ldap_serverconfig_chooser: this.configID});
+			var params = OC.buildQueryString({id: this.configID});
 			var model = this;
 			this.executeAfterSet(function(){
 				$.post(url, params, function(result) { model._processTestResult(model, result) });

--- a/js/wizard/view.js
+++ b/js/wizard/view.js
@@ -271,7 +271,7 @@ OCA = OCA || {};
 		 * requests a configuration test
 		 */
 		onTestButtonClick: function() {
-			this.configModel.requestWizard('ldap_action_test_connection', {ldap_serverconfig_chooser: this.configModel.configID});
+			this.configModel.requestWizard('ldap_action_test_connection', {id: this.configModel.configID});
 		},
 
 		/**

--- a/js/wizard/wizardDetectorAvailableAttributes.js
+++ b/js/wizard/wizardDetectorAvailableAttributes.js
@@ -35,7 +35,7 @@ OCA = OCA || {};
 			model.notifyAboutDetectionStart(this.getTargetKey());
 			var params = OC.buildQueryString({
 				action: 'determineAttributes',
-				ldap_serverconfig_chooser: configID
+				id: configID
 			});
 			return model.callWizard(params, this.processResult, this);
 		},

--- a/js/wizard/wizardDetectorBaseDN.js
+++ b/js/wizard/wizardDetectorBaseDN.js
@@ -42,7 +42,7 @@ OCA = OCA || {};
 			model.notifyAboutDetectionStart(this.getTargetKey());
 			var params = OC.buildQueryString({
 				action: 'guessBaseDN',
-				ldap_serverconfig_chooser: configID
+				id: configID
 			});
 			return model.callWizard(params, this.processResult, this);
 		}

--- a/js/wizard/wizardDetectorFeatureAbstract.js
+++ b/js/wizard/wizardDetectorFeatureAbstract.js
@@ -27,7 +27,7 @@ OCA = OCA || {};
 			model.notifyAboutDetectionStart(this.getTargetKey());
 			var params = OC.buildQueryString({
 				action: this.wizardMethod,
-				ldap_serverconfig_chooser: configID
+				id: configID
 			});
 			return model.callWizard(params, this.processResult, this);
 		},

--- a/js/wizard/wizardDetectorPort.js
+++ b/js/wizard/wizardDetectorPort.js
@@ -34,7 +34,7 @@ OCA = OCA || {};
 			model.notifyAboutDetectionStart('ldap_port');
 			var params = OC.buildQueryString({
 				action: 'guessPortAndTLS',
-				ldap_serverconfig_chooser: configID
+				id: configID
 			});
 			return model.callWizard(params, this.processResult, this);
 		}

--- a/js/wizard/wizardDetectorSimpleRequestAbstract.js
+++ b/js/wizard/wizardDetectorSimpleRequestAbstract.js
@@ -34,7 +34,7 @@ OCA = OCA || {};
 			model.notifyAboutDetectionStart(this.targetKey);
 			var params = OC.buildQueryString({
 				action: this.wizardMethod,
-				ldap_serverconfig_chooser: configID
+				id: configID
 			});
 			return model.callWizard(params, this.processResult, this);
 		}

--- a/js/wizard/wizardDetectorTestAbstract.js
+++ b/js/wizard/wizardDetectorTestAbstract.js
@@ -37,7 +37,7 @@ OCA = OCA || {};
 			params = params || {};
 			params = OC.buildQueryString($.extend({
 				action: this.wizardMethod,
-				ldap_serverconfig_chooser: configID
+				id: configID
 			}, params));
 			if(!this.isLegacy) {
 				return model.callWizard(params, this.processResult, this);

--- a/js/wizard/wizardTabExpert.js
+++ b/js/wizard/wizardTabExpert.js
@@ -97,14 +97,14 @@ OCA = OCA || {};
 		 * requests clearing of all user mappings
 		 */
 		onClearUserMappingsClick: function() {
-			this.configModel.requestWizard('ldap_action_clear_user_mappings', {ldap_clear_mapping: 'user'});
+			this.configModel.requestWizard('ldap_action_clear_user_mappings', {subject: 'user'});
 		},
 
 		/**
 		 * requests clearing of all group mappings
 		 */
 		onClearGroupMappingsClick: function() {
-			this.configModel.requestWizard('ldap_action_clear_group_mappings', {ldap_clear_mapping: 'group'});
+			this.configModel.requestWizard('ldap_action_clear_group_mappings', {subject: 'group'});
 		},
 
 		/**

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -106,16 +106,15 @@ class ConfigurationController extends Controller {
 		$resultData['status'] = 'success';
 		return new DataResponse($resultData);
 	}
+
 	/**
 	 * get the given ldap config
 	 *
-	 * @param string $ldap_serverconfig_chooser config id
+	 * @param string $id config id
 	 * @return DataResponse
 	 */
-	public function read($ldap_serverconfig_chooser) {
-		$prefix = $ldap_serverconfig_chooser; // TODO if possible make JS send as 'prefix' right away
-
-		$configuration = new Configuration($this->config, $prefix);
+	public function read($id) {
+		$configuration = new Configuration($this->config, $id);
 		$connection = new Connection($this->ldapWrapper, $configuration);
 
 		$configuration = $connection->getConfiguration();
@@ -132,13 +131,11 @@ class ConfigurationController extends Controller {
 	/**
 	 * test the given ldap config
 	 *
-	 * @param string $ldap_serverconfig_chooser config id
+	 * @param string $id config id
 	 * @return DataResponse
 	 */
-	public function test($ldap_serverconfig_chooser) {
-		$prefix = $ldap_serverconfig_chooser; // TODO if possible make JS send as 'prefix' right away
-
-		$configuration = new Configuration($this->config, $prefix);
+	public function test($id) {
+		$configuration = new Configuration($this->config, $id);
 		$connection = new Connection($this->ldapWrapper, $configuration);
 
 		try {
@@ -201,14 +198,13 @@ class ConfigurationController extends Controller {
 	}
 
 	/**
-	 * get the given ldap config
+	 * delete the given ldap config
 	 *
-	 * @param string $ldap_serverconfig_chooser config id
+	 * @param string $id config id
 	 * @return DataResponse
 	 */
-	public function delete($ldap_serverconfig_chooser) {
-		$prefix = $ldap_serverconfig_chooser; // TODO if possible make JS send as 'prefix' right away
-		if ($this->helper->deleteServerConfiguration($prefix)) {
+	public function delete($id) {
+		if ($this->helper->deleteServerConfiguration($id)) {
 			return new DataResponse(['status' => 'success']);
 		}
 		return new DataResponse([

--- a/lib/Controller/MappingController.php
+++ b/lib/Controller/MappingController.php
@@ -62,12 +62,11 @@ class MappingController extends Controller {
 	/**
 	 * test the given ldap config
 	 *
-	 * @param string $ldap_clear_mapping subject, 'group' or 'user'
-	 * @param string $ldap_serverconfig_chooser config id // FIXME remove in JS, is unneeded
+	 * @param string $subject, 'group' or 'user'
+	 *
 	 * @return DataResponse
 	 */
-	public function clear($ldap_clear_mapping, $ldap_serverconfig_chooser = null) {
-		$subject = $ldap_clear_mapping; // TODO if possible make JS send as 'subject' right away
+	public function clear($subject) {
 		$mapping = null;
 		if ($subject === 'user') {
 			$mapping = new UserMapping($this->connection);

--- a/lib/Controller/WizardController.php
+++ b/lib/Controller/WizardController.php
@@ -94,17 +94,15 @@ class WizardController extends Controller {
 	/**
 	 * do your magic
 	 *
-	 * @param string $ldap_serverconfig_chooser config id
+	 * @param string $id config id
 	 * @param string $action the spell to cast
 	 * @param string $cfgkey optional
 	 * @param string $cfgval optional
 	 * @param string $ldap_test_loginname optional
 	 * @return DataResponse
 	 */
-	public function cast($ldap_serverconfig_chooser, $action, $cfgkey = null, $cfgval = null, $ldap_test_loginname = null) {
-		$prefix = $ldap_serverconfig_chooser; // TODO if possible make JS send as 'prefix' right away
-
-		$config = new Configuration($this->config, $prefix);
+	public function cast($id, $action, $cfgkey = null, $cfgval = null, $ldap_test_loginname = null) {
+		$config = new Configuration($this->config, $id);
 
 		switch ($action) {
 			case 'guessPortAndTLS':
@@ -179,7 +177,7 @@ class WizardController extends Controller {
 				}
 				$config->saveConfiguration();
 				//clear the cache on save
-				$configuration = new Configuration($this->config, $prefix);
+				$configuration = new Configuration($this->config, $id);
 				$connection = new Connection($this->ldapWrapper, $configuration);
 				$connection->clearCache();
 				return new DataResponse(['status' => 'success']);


### PR DESCRIPTION
Do some TODOs and fix one FIXME 

Basically renames 
`ldap_serverconfig_chooser` into `id` to match https://github.com/owncloud/user_ldap/pull/210
`ldap_clear_mapping` into `subject`

