### PR TITLE
Fix false negative result when deleting a server configuration

### DIFF
--- a/lib/Helper.php
+++ b/lib/Helper.php
@@ -110,7 +110,7 @@ class Helper {
 			return false;
 		}
 
-		if ($result->rowCount() === 0) {
+		if ($result === 0) {
 			return false;
 		}
 


### PR DESCRIPTION
Discovered while testing https://github.com/owncloud/user_ldap/pull/407
Config deletion didn't remove it from dropdown because deleteServerConfiguration had false negative result.