### PR TITLE
Store arrays as arrays, do not use newline as a separator

### DIFF
--- a/appinfo/Migrations/Version20190315192717.php
+++ b/appinfo/Migrations/Version20190315192717.php
@@ -140,6 +140,8 @@ class Version20190315192717 implements ISimpleMigration {
 		'ldap_paging_size'                  => 'ldapPagingSize',
 		'ldap_experienced_admin'            => 'ldapExperiencedAdmin',
 		'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
+		'ldap_uuid_user_attribute'          => 'ldapUuidUserAttribute',
+		'ldap_uuid_group_attribute'         => 'ldapUuidGroupAttribute'
 	];
 
 	/**
@@ -279,9 +281,10 @@ class Version20190315192717 implements ISimpleMigration {
 
 	/**
 	 * @param  mixed $value
-	 * @return string[]
+	 * @return string | string[]
 	 */
 	private function convertToArray($value) {
+		// try to split the value by all known separators
 		if (empty($value)) {
 			$value = '';
 		} elseif (!\is_array($value)) {
@@ -292,8 +295,10 @@ class Version20190315192717 implements ISimpleMigration {
 		}
 
 		if (!\is_array($value)) {
+			// if the value is not an array - store it as is
 			$finalValue = \trim($value);
 		} else {
+			// if the value is an array - clean all empty values
 			$finalValue = [];
 			foreach ($value as $key => $val) {
 				if (\is_string($val)) {

--- a/appinfo/Migrations/Version20190315192717.php
+++ b/appinfo/Migrations/Version20190315192717.php
@@ -143,6 +143,22 @@ class Version20190315192717 implements ISimpleMigration {
 	];
 
 	/**
+	 * @var string[] - config keys that should be converted into an array
+	 */
+	private $arrayConfigKeys = [
+		'ldapBase',
+		'ldapBaseUsers',
+		'ldapBaseGroups',
+		'ldapAttributesForUserSearch',
+		'ldapAttributesForGroupSearch',
+		'ldapUserFilterObjectclass',
+		'ldapUserFilterGroups',
+		'ldapGroupFilterObjectclass',
+		'ldapGroupFilterGroups',
+		'ldapLoginFilterAttributes'
+	];
+
+	/**
 	 * @var IConfig
 	 */
 	private $config;
@@ -252,7 +268,48 @@ class Version20190315192717 implements ISimpleMigration {
 			}
 		}
 
+		foreach ($this->arrayConfigKeys as $arrayConfigKey) {
+			if (isset($current[$arrayConfigKey])) {
+				$current[$arrayConfigKey] = $this->convertToArray($current[$arrayConfigKey]);
+			}
+		}
+
 		return $current;
+	}
+
+	/**
+	 * @param  mixed $value
+	 * @return string[]
+	 */
+	private function convertToArray($value) {
+		if (empty($value)) {
+			$value = '';
+		} elseif (!\is_array($value)) {
+			$value = \preg_split('/\r\n|\r|\n|;/', $value);
+			if ($value === false) {
+				$value = '';
+			}
+		}
+
+		if (!\is_array($value)) {
+			$finalValue = \trim($value);
+		} else {
+			$finalValue = [];
+			foreach ($value as $key => $val) {
+				if (\is_string($val)) {
+					$val = \trim($val);
+					if ($val !== '') {
+						//accidental line breaks are not wanted and can cause
+						// odd behaviour. Thus, away with them.
+						$finalValue[] = $val;
+					}
+				} else {
+					$finalValue[] = $val;
+				}
+			}
+		}
+
+		return $finalValue;
 	}
 
 	/**

--- a/js/wizard/configModel.js
+++ b/js/wizard/configModel.js
@@ -33,6 +33,60 @@ OCA = OCA || {};
 		 * @param {OCA.LDAP.Wizard.WizardDetectorQueue} detectorQueue
 		 */
 		init: function (detectorQueue) {
+			this.mappings = {
+				'ldapHost'                      : 'ldap_host',
+				'ldapPort'                      : 'ldap_port',
+				'ldapBackupHost'                : 'ldap_backup_host',
+				'ldapBackupPort'                : 'ldap_backup_port',
+				'ldapOverrideMainServer'        : 'ldap_override_main_server',
+				'ldapAgentName'                 : 'ldap_dn',
+				'ldapAgentPassword'             : 'ldap_agent_password',
+				'ldapBase'                      : 'ldap_base',
+				'ldapBaseUsers'                 : 'ldap_base_users',
+				'ldapBaseGroups'                : 'ldap_base_groups',
+				'ldapUserFilterObjectclass'     : 'ldap_userfilter_objectclass',
+				'ldapUserFilterGroups'          : 'ldap_userfilter_groups',
+				'ldapUserFilter'                : 'ldap_userlist_filter',
+				'ldapUserFilterMode'            : 'ldap_user_filter_mode',
+				'ldapLoginFilter'               : 'ldap_login_filter',
+				'ldapLoginFilterMode'           : 'ldap_login_filter_mode',
+				'ldapLoginFilterEmail'          : 'ldap_loginfilter_email',
+				'ldapLoginFilterUsername'       : 'ldap_loginfilter_username',
+				'ldapLoginFilterAttributes'     : 'ldap_loginfilter_attributes',
+				'ldapGroupFilter'               : 'ldap_group_filter',
+				'ldapGroupFilterMode'           : 'ldap_group_filter_mode',
+				'ldapGroupFilterObjectclass'    : 'ldap_groupfilter_objectclass',
+				'ldapGroupFilterGroups'         : 'ldap_groupfilter_groups',
+				'ldapUserName'                  : 'ldap_user_name',
+				'ldapUserDisplayName'           : 'ldap_display_name',
+				'ldapUserDisplayName2'          : 'ldap_user_display_name_2',
+				'ldapGroupDisplayName'          : 'ldap_group_display_name',
+				'ldapTLS'                       : 'ldap_tls',
+				'ldapQuotaDefault'              : 'ldap_quota_def',
+				'ldapQuotaAttribute'            : 'ldap_quota_attr',
+				'ldapEmailAttribute'            : 'ldap_email_attr',
+				'ldapGroupMemberAssocAttr'      : 'ldap_group_member_assoc_attribute',
+				'ldapCacheTTL'                  : 'ldap_cache_ttl',
+				'ldapNetworkTimeout'            : 'ldap_network_timeout',
+				'homeFolderNamingRule'          : 'home_folder_naming_rule',
+				'turnOffCertCheck'              : 'ldap_turn_off_cert_check',
+				'ldapConfigurationActive'       : 'ldap_configuration_active',
+				'ldapAttributesForUserSearch'   : 'ldap_attributes_for_user_search',
+				'ldapAttributesForGroupSearch'  : 'ldap_attributes_for_group_search',
+				'ldapExpertUsernameAttr'        : 'ldap_expert_username_attr',
+				'ldapExpertUUIDUserAttr'        : 'ldap_expert_uuid_user_attr',
+				'ldapExpertUUIDGroupAttr'       : 'ldap_expert_uuid_group_attr',
+				'hasMemberOfFilterSupport'      : 'has_memberof_filter_support',
+				'useMemberOfToDetectMembership' : 'use_memberof_to_detect_membership',
+				'lastJpegPhotoLookup'           : 'last_jpegPhoto_lookup',
+				'ldapNestedGroups'              : 'ldap_nested_groups',
+				'ldapPagingSize'                : 'ldap_paging_size',
+				'ldapExperiencedAdmin'          : 'ldap_experienced_admin',
+				'ldapDynamicGroupMemberURL'     : 'ldap_dynamic_group_member_url',
+				'ldapUuidUserAttribute'         : 'ldap_uuid_user_attribute',
+				'ldapUuidGroupAttribute'        : 'ldap_uuid_group_attribute'
+			};
+
 			this.modifyingAjaxCalls = [];
 			/** @type {object} holds the configuration in key-value-pairs */
 			this.configuration     = {};
@@ -46,6 +100,14 @@ OCA = OCA || {};
 			if(detectorQueue instanceof OCA.LDAP.Wizard.WizardDetectorQueue) {
 				/** @type {OCA.LDAP.Wizard.WizardDetectorQueue} */
 				this.detectorQueue = detectorQueue;
+			}
+		},
+
+		translateForBackend : function (key) {
+			for (var i in this.mappings){
+				if (this.mappings[i] == key){
+					return i;
+				}
 			}
 		},
 
@@ -135,7 +197,15 @@ OCA = OCA || {};
 			var url = OC.generateUrl('apps/user_ldap/ajax/' + destination);
 			var model = this;
 			return $.post(url, params, function (result) {
-				callback(model, detector,result);
+				if (result['changes']) {
+					var changes = {};
+					$.each(result['changes'], function(key, value) {
+						key = model.mappings[key] || key;
+						changes[key] = value;
+					});
+					result['changes'] = changes;
+				}
+				callback(model, detector, result);
 			});
 		},
 
@@ -175,12 +245,13 @@ OCA = OCA || {};
 			var objParams = {
 				id: this.configID,
 				action: 'save',
-				cfgkey: key,
+				cfgkey: this.translateForBackend(key) || key,
 				cfgval: value
 			};
 			var strParams = OC.buildQueryString(objParams);
 			var model = this;
 			var ajaxCall = $.post(url, strParams, function(result) {
+				objParams.cfgkey = key;
 				model._processSetResult(model, result, objParams);
 				// remove this ajax call from the list to clean up
 				model.modifyingAjaxCalls = _.without(model.modifyingAjaxCalls, ajaxCall);
@@ -447,6 +518,7 @@ OCA = OCA || {};
 			model.configuration = {};
 			if(result['status'] === 'success') {
 				$.each(result['configuration'], function(key, value) {
+					key = model.mappings[key] || key;
 					model.configuration[key] = value;
 				});
 			}
@@ -595,6 +667,7 @@ OCA = OCA || {};
 				if(!copyCurrent) {
 					model.configuration = {};
 					$.each(result['defaults'], function(key, value) {
+						key = model.mappings[key] || key;
 						model.configuration[key] = value;
 					});
 					// view / tabs need to update with new blank config

--- a/lib/Command/TestConfig.php
+++ b/lib/Command/TestConfig.php
@@ -102,7 +102,7 @@ class TestConfig extends Command {
 		$connection->getConfiguration();
 
 		if (!$connection->setConfiguration([
-			'ldap_configuration_active' => 1,
+			'ldapConfigurationActive' => 1,
 		])) {
 			return 1;
 		}

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -102,6 +102,19 @@ class Configuration {
 		'ldapDynamicGroupMemberURL' => null,
 	];
 
+	protected $arrayConfigKeys = [
+		'ldapBase',
+		'ldapBaseUsers',
+		'ldapBaseGroups',
+		'ldapAttributesForUserSearch',
+		'ldapAttributesForGroupSearch',
+		'ldapUserFilterObjectclass',
+		'ldapUserFilterGroups',
+		'ldapGroupFilterObjectclass',
+		'ldapGroupFilterGroups',
+		'ldapLoginFilterAttributes'
+	];
+
 	protected $rawConnData;
 
 	/**
@@ -233,18 +246,6 @@ class Configuration {
 					continue;
 				}
 				switch ($key) {
-					case 'ldapBase':
-					case 'ldapBaseUsers':
-					case 'ldapBaseGroups':
-					case 'ldapAttributesForUserSearch':
-					case 'ldapAttributesForGroupSearch':
-					case 'ldapUserFilterObjectclass':
-					case 'ldapUserFilterGroups':
-					case 'ldapGroupFilterObjectclass':
-					case 'ldapGroupFilterGroups':
-					case 'ldapLoginFilterAttributes':
-						$readMethod = 'getMultiLine';
-						break;
 					case 'ldapIgnoreNamingRules':
 						$readMethod = 'getSystemValue';
 						break;
@@ -255,6 +256,16 @@ class Configuration {
 					case 'ldapGroupDisplayName':
 						$readMethod = 'getLcValue';
 						break;
+					case 'ldapBase':
+					case 'ldapBaseUsers':
+					case 'ldapBaseGroups':
+					case 'ldapAttributesForUserSearch':
+					case 'ldapAttributesForGroupSearch':
+					case 'ldapUserFilterObjectclass':
+					case 'ldapUserFilterGroups':
+					case 'ldapGroupFilterObjectclass':
+					case 'ldapGroupFilterGroups':
+					case 'ldapLoginFilterAttributes':
 					case 'ldapUserDisplayName':
 					default:
 						// user display name does not lower case because
@@ -275,20 +286,6 @@ class Configuration {
 			switch ($key) {
 				case 'ldapAgentPassword':
 					$value = \base64_encode($value);
-					break;
-				case 'ldapBase':
-				case 'ldapBaseUsers':
-				case 'ldapBaseGroups':
-				case 'ldapAttributesForUserSearch':
-				case 'ldapAttributesForGroupSearch':
-				case 'ldapUserFilterObjectclass':
-				case 'ldapUserFilterGroups':
-				case 'ldapGroupFilterObjectclass':
-				case 'ldapGroupFilterGroups':
-				case 'ldapLoginFilterAttributes':
-					if (\is_array($value)) {
-						$value = \implode("\n", $value);
-					}
 					break;
 				//following options are not stored but detected, skip them
 				case 'ldapIgnoreNamingRules':
@@ -316,23 +313,17 @@ class Configuration {
 	}
 
 	public function isDefault() {
-		$diff = \array_diff_assoc($this->getTranslatedConfig(), $this->getDefaults());
-		return \count($diff) === 0;
-	}
-
-	/**
-	 * @param string $varName
-	 * @return array|string
-	 */
-	protected function getMultiLine($varName) {
-		$value = $this->getValue($varName);
-		if (empty($value)) {
-			$value = '';
-		} else {
-			$value = \preg_split('/\r\n|\r|\n/', $value);
+		$c = $this->getTranslatedConfig();
+		// multiple values means the config is not default
+		foreach ($this->arrayConfigKeys as $arrayConfigKey) {
+			if (\array_key_exists($arrayConfigKey, $c) === false
+				|| \is_array($c[$arrayConfigKey])
+			) {
+				return false;
+			}
 		}
-
-		return $value;
+		$diff = \array_diff_assoc($c, $this->getDefaults());
+		return \count($diff) === 0;
 	}
 
 	/**

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -46,74 +46,7 @@ class Configuration {
 	protected $read = false;
 
 	/** @var array */
-	protected $data = [
-		'ldapHost' => null,
-		'ldapPort' => null,
-		'ldapBackupHost' => null,
-		'ldapBackupPort' => null,
-		'ldapBase' => null,
-		'ldapBaseUsers' => null,
-		'ldapBaseGroups' => null,
-		'ldapAgentName' => null,
-		'ldapAgentPassword' => null,
-		'ldapTLS' => null,
-		'turnOffCertCheck' => null,
-		'ldapIgnoreNamingRules' => null,
-		'ldapUserName' => null,
-		'ldapUserDisplayName' => null,
-		'ldapUserDisplayName2' => null,
-		'ldapUserFilterObjectclass' => null,
-		'ldapUserFilterGroups' => null,
-		'ldapUserFilter' => null,
-		'ldapUserFilterMode' => null,
-		'ldapGroupFilter' => null,
-		'ldapGroupFilterMode' => null,
-		'ldapGroupFilterObjectclass' => null,
-		'ldapGroupFilterGroups' => null,
-		'ldapGroupDisplayName' => null,
-		'ldapGroupMemberAssocAttr' => null,
-		'ldapLoginFilter' => null,
-		'ldapLoginFilterMode' => null,
-		'ldapLoginFilterEmail' => null,
-		'ldapLoginFilterUsername' => null,
-		'ldapLoginFilterAttributes' => null,
-		'ldapQuotaAttribute' => null,
-		'ldapQuotaDefault' => null,
-		'ldapEmailAttribute' => null,
-		'ldapCacheTTL' => null,
-		'ldapNetworkTimeout' => null,
-		'ldapUuidUserAttribute' => 'auto',
-		'ldapUuidGroupAttribute' => 'auto',
-		'ldapOverrideMainServer' => false,
-		'ldapConfigurationActive' => false,
-		'ldapAttributesForUserSearch' => null,
-		'ldapAttributesForGroupSearch' => null,
-		'ldapExperiencedAdmin' => false,
-		'homeFolderNamingRule' => null,
-		'hasPagedResultSupport' => false,
-		'hasMemberOfFilterSupport' => false,
-		'useMemberOfToDetectMembership' => true,
-		'ldapExpertUsernameAttr' => null,
-		'ldapExpertUUIDUserAttr' => null,
-		'ldapExpertUUIDGroupAttr' => null,
-		'lastJpegPhotoLookup' => null,
-		'ldapNestedGroups' => false,
-		'ldapPagingSize' => null,
-		'ldapDynamicGroupMemberURL' => null,
-	];
-
-	protected $arrayConfigKeys = [
-		'ldapBase',
-		'ldapBaseUsers',
-		'ldapBaseGroups',
-		'ldapAttributesForUserSearch',
-		'ldapAttributesForGroupSearch',
-		'ldapUserFilterObjectclass',
-		'ldapUserFilterGroups',
-		'ldapGroupFilterObjectclass',
-		'ldapGroupFilterGroups',
-		'ldapLoginFilterAttributes'
-	];
+	protected $data = [];
 
 	protected $rawConnData;
 
@@ -125,6 +58,7 @@ class Configuration {
 	public function __construct(IConfig $coreConfig, $prefix, $autoRead = true) {
 		$this->coreConfig = $coreConfig;
 		$this->prefix = $prefix;
+		$this->data = $this->getDefaults();
 		if ($autoRead) {
 			$this->readConfiguration();
 		}
@@ -313,17 +247,15 @@ class Configuration {
 	}
 
 	public function isDefault() {
-		$c = $this->getTranslatedConfig();
-		// multiple values means the config is not default
-		foreach ($this->arrayConfigKeys as $arrayConfigKey) {
-			if (\array_key_exists($arrayConfigKey, $c) === false
-				|| \is_array($c[$arrayConfigKey])
+		$defaults = $this->getDefaults();
+		foreach ($this->getTranslatedConfig() as $key=>$value) {
+			if (\array_key_exists($key, $defaults) === false
+				|| $defaults[$key] !== $value
 			) {
 				return false;
 			}
 		}
-		$diff = \array_diff_assoc($c, $this->getDefaults());
-		return \count($diff) === 0;
+		return true;
 	}
 
 	/**
@@ -463,8 +395,8 @@ class Configuration {
 			'ldapGroupMemberAssocAttr'       => 'uniqueMember',
 			'ldapCacheTTL'                   => 600,
 			'ldapNetworkTimeout'             => 2,
-			'ldap_uuid_user_attribute'       => 'auto',
-			'ldap_uuid_group_attribute'      => 'auto',
+			'ldapUuidUserAttribute'          => 'auto',
+			'ldapUuidGroupAttribute'         => 'auto',
 			'homeFolderNamingRule'           => '',
 			'turnOffCertCheck'               => 0,
 			'ldapConfigurationActive'        => 0,
@@ -480,6 +412,7 @@ class Configuration {
 			'ldapPagingSize'                 => 500,
 			'ldapExperiencedAdmin'           => 0,
 			'ldapDynamicGroupMemberURL'      => '',
+			'ldapIgnoreNamingRules'          => false
 		];
 	}
 

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -124,11 +124,8 @@ class Configuration {
 			return false;
 		}
 
-		$cta = $this->getConfigTranslationArray();
 		foreach ($config as $inputKey => $val) {
-			if (\strpos($inputKey, '_') !== false && \array_key_exists($inputKey, $cta)) {
-				$key = $cta[$inputKey];
-			} elseif (\array_key_exists($inputKey, $this->data)) {
+			if (\array_key_exists($inputKey, $this->data)) {
 				$key = $inputKey;
 			} else {
 				continue;
@@ -173,9 +170,9 @@ class Configuration {
 			);
 			$this->rawConnData = \json_decode($conn, true);
 
-			$cta = \array_flip($this->getConfigTranslationArray());
+			$defaults = $this->getDefaults();
 			foreach ($this->data as $key => $val) {
-				if (!isset($cta[$key])) {
+				if (!\array_key_exists($key, $defaults)) {
 					//some are determined
 					continue;
 				}
@@ -414,64 +411,5 @@ class Configuration {
 			'ldapDynamicGroupMemberURL'      => '',
 			'ldapIgnoreNamingRules'          => false
 		];
-	}
-
-	/**
-	 * @return array that maps internal variable names to database fields
-	 */
-	public function getConfigTranslationArray() {
-		//TODO: merge them into one representation
-		static $array = [
-			'ldap_host'                         => 'ldapHost',
-			'ldap_port'                         => 'ldapPort',
-			'ldap_backup_host'                  => 'ldapBackupHost',
-			'ldap_backup_port'                  => 'ldapBackupPort',
-			'ldap_override_main_server'         => 'ldapOverrideMainServer',
-			'ldap_dn'                           => 'ldapAgentName',
-			'ldap_agent_password'               => 'ldapAgentPassword',
-			'ldap_base'                         => 'ldapBase',
-			'ldap_base_users'                   => 'ldapBaseUsers',
-			'ldap_base_groups'                  => 'ldapBaseGroups',
-			'ldap_userfilter_objectclass'       => 'ldapUserFilterObjectclass',
-			'ldap_userfilter_groups'            => 'ldapUserFilterGroups',
-			'ldap_userlist_filter'              => 'ldapUserFilter',
-			'ldap_user_filter_mode'             => 'ldapUserFilterMode',
-			'ldap_login_filter'                 => 'ldapLoginFilter',
-			'ldap_login_filter_mode'            => 'ldapLoginFilterMode',
-			'ldap_loginfilter_email'            => 'ldapLoginFilterEmail',
-			'ldap_loginfilter_username'         => 'ldapLoginFilterUsername',
-			'ldap_loginfilter_attributes'       => 'ldapLoginFilterAttributes',
-			'ldap_group_filter'                 => 'ldapGroupFilter',
-			'ldap_group_filter_mode'            => 'ldapGroupFilterMode',
-			'ldap_groupfilter_objectclass'      => 'ldapGroupFilterObjectclass',
-			'ldap_groupfilter_groups'           => 'ldapGroupFilterGroups',
-			'ldap_user_name'                    => 'ldapUserName',
-			'ldap_display_name'                 => 'ldapUserDisplayName',
-			'ldap_user_display_name_2'			=> 'ldapUserDisplayName2',
-			'ldap_group_display_name'           => 'ldapGroupDisplayName',
-			'ldap_tls'                          => 'ldapTLS',
-			'ldap_quota_def'                    => 'ldapQuotaDefault',
-			'ldap_quota_attr'                   => 'ldapQuotaAttribute',
-			'ldap_email_attr'                   => 'ldapEmailAttribute',
-			'ldap_group_member_assoc_attribute' => 'ldapGroupMemberAssocAttr',
-			'ldap_cache_ttl'                    => 'ldapCacheTTL',
-			'ldap_network_timeout'              => 'ldapNetworkTimeout',
-			'home_folder_naming_rule'           => 'homeFolderNamingRule',
-			'ldap_turn_off_cert_check'          => 'turnOffCertCheck',
-			'ldap_configuration_active'         => 'ldapConfigurationActive',
-			'ldap_attributes_for_user_search'   => 'ldapAttributesForUserSearch',
-			'ldap_attributes_for_group_search'  => 'ldapAttributesForGroupSearch',
-			'ldap_expert_username_attr'         => 'ldapExpertUsernameAttr',
-			'ldap_expert_uuid_user_attr'        => 'ldapExpertUUIDUserAttr',
-			'ldap_expert_uuid_group_attr'       => 'ldapExpertUUIDGroupAttr',
-			'has_memberof_filter_support'       => 'hasMemberOfFilterSupport',
-			'use_memberof_to_detect_membership' => 'useMemberOfToDetectMembership',
-			'last_jpegPhoto_lookup'             => 'lastJpegPhotoLookup',
-			'ldap_nested_groups'                => 'ldapNestedGroups',
-			'ldap_paging_size'                  => 'ldapPagingSize',
-			'ldap_experienced_admin'            => 'ldapExperiencedAdmin',
-			'ldap_dynamic_group_member_url'     => 'ldapDynamicGroupMemberURL',
-		];
-		return $array;
 	}
 }

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -294,15 +294,15 @@ class Connection extends LDAPUtility {
 	public function getConfiguration() {
 		$this->readConfiguration();
 		$config = $this->configuration->getConfiguration();
-		$cta = $this->configuration->getConfigTranslationArray();
+		$defaults = $this->configuration->getDefaults();
 		$result = [];
-		foreach ($cta as $dbkey => $configkey) {
+		foreach (\array_keys($defaults) as $configkey) {
 			switch ($configkey) {
 				case 'homeFolderNamingRule':
 					if (\strpos($config[$configkey], 'attr:') === 0) {
-						$result[$dbkey] = \substr($config[$configkey], 5);
+						$result[$configkey] = \substr($config[$configkey], 5);
 					} else {
-						$result[$dbkey] = '';
+						$result[$configkey] = '';
 					}
 					break;
 				case 'ldapBase':
@@ -311,12 +311,12 @@ class Connection extends LDAPUtility {
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
 					if (\is_array($config[$configkey])) {
-						$result[$dbkey] = \implode("\n", $config[$configkey]);
+						$result[$configkey] = \implode("\n", $config[$configkey]);
 						break;
 					} //else follows default
 					// no break
 				default:
-					$result[$dbkey] = $config[$configkey];
+					$result[$configkey] = $config[$configkey];
 			}
 		}
 		return $result;

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -118,9 +118,9 @@ class ConfigurationController extends Controller {
 		$connection = new Connection($this->ldapWrapper, $configuration);
 
 		$configuration = $connection->getConfiguration();
-		if (isset($configuration['ldap_agent_password']) && $configuration['ldap_agent_password'] !== '') {
+		if (isset($configuration['ldapAgentPassword']) && $configuration['ldapAgentPassword'] !== '') {
 			// hide password
-			$configuration['ldap_agent_password'] = '**PASSWORD SET**';
+			$configuration['ldapAgentPassword'] = '**PASSWORD SET**';
 		}
 		return new DataResponse([
 			'status' => 'success',
@@ -141,9 +141,9 @@ class ConfigurationController extends Controller {
 		try {
 			$configurationOk = true;
 			$conf = $connection->getConfiguration();
-			if ($conf['ldap_configuration_active'] === '0') {
+			if ($conf['ldapConfigurationActive'] === '0') {
 				//needs to be true, otherwise it will also fail with an irritating message
-				$conf['ldap_configuration_active'] = '1';
+				$conf['ldapConfigurationActive'] = '1';
 				$configurationOk = $connection->setConfiguration($conf);
 			}
 			if ($configurationOk) {

--- a/lib/Wizard.php
+++ b/lib/Wizard.php
@@ -232,7 +232,7 @@ class Wizard extends LDAPUtility {
 			if ($count > 0) {
 				//no change, but we sent it back to make sure the user interface
 				//is still correct, even if the ajax call was cancelled meanwhile
-				$this->result->addChange('ldap_display_name', $attr);
+				$this->result->addChange('ldapUserDisplayName', $attr);
 				return $this->result;
 			}
 		}
@@ -243,7 +243,7 @@ class Wizard extends LDAPUtility {
 			$count = (int)$this->countUsersWithAttribute($attr, true);
 
 			if ($count > 0) {
-				$this->applyFind('ldap_display_name', $attr);
+				$this->applyFind('ldapUserDisplayName', $attr);
 				return $this->result;
 			}
 		};
@@ -289,7 +289,7 @@ class Wizard extends LDAPUtility {
 		}
 
 		if ($winner !== '') {
-			$this->applyFind('ldap_email_attr', $winner);
+			$this->applyFind('ldapEmailAttribute', $winner);
 			if ($writeLog) {
 				\OCP\Util::writeLog('user_ldap', 'The mail attribute has ' .
 					'automatically been reset, because the original value ' .
@@ -318,11 +318,11 @@ class Wizard extends LDAPUtility {
 		\natcasesort($attributes);
 		$attributes = \array_values($attributes);
 
-		$this->result->addOptions('ldap_loginfilter_attributes', $attributes);
+		$this->result->addOptions('ldapLoginFilterAttributes', $attributes);
 
 		$selected = $this->configuration->ldapLoginFilterAttributes;
 		if (\is_array($selected) && !empty($selected)) {
-			$this->result->addChange('ldap_loginfilter_attributes', $selected);
+			$this->result->addChange('ldapLoginFilterAttributes', $selected);
 		}
 
 		return $this->result;
@@ -367,7 +367,7 @@ class Wizard extends LDAPUtility {
 	 * @return WizardResult|false the instance's WizardResult instance
 	 */
 	public function determineGroupsForGroups() {
-		return $this->determineGroups('ldap_groupfilter_groups',
+		return $this->determineGroups('ldapGroupFilterGroups',
 									  'ldapGroupFilterGroups',
 									  false);
 	}
@@ -377,7 +377,7 @@ class Wizard extends LDAPUtility {
 	 * @return WizardResult|false the instance's WizardResult instance
 	 */
 	public function determineGroupsForUsers() {
-		return $this->determineGroups('ldap_userfilter_groups',
+		return $this->determineGroups('ldapUserFilterGroups',
 									  'ldapUserFilterGroups');
 	}
 
@@ -481,7 +481,7 @@ class Wizard extends LDAPUtility {
 			return false;
 		}
 		$this->configuration->setConfiguration(['ldapGroupMemberAssocAttr' => $attribute]);
-		$this->result->addChange('ldap_group_member_assoc_attribute', $attribute);
+		$this->result->addChange('ldapGroupMemberAssocAttr', $attribute);
 
 		return $this->result;
 	}
@@ -506,7 +506,7 @@ class Wizard extends LDAPUtility {
 		$obclasses = ['groupOfNames', 'group', 'posixGroup', 'groupOfUniqueNames', '*'];
 		$this->determineFeature($obclasses,
 								'objectclass',
-								'ldap_groupfilter_objectclass',
+								'ldapGroupFilterObjectclass',
 								'ldapGroupFilterObjectclass',
 								false);
 
@@ -537,7 +537,7 @@ class Wizard extends LDAPUtility {
 		//then, apply suggestions.
 		$this->determineFeature($obclasses,
 								'objectclass',
-								'ldap_userfilter_objectclass',
+								'ldapUserFilterObjectclass',
 								'ldapUserFilterObjectclass',
 								empty($filter));
 
@@ -559,12 +559,12 @@ class Wizard extends LDAPUtility {
 		$displayName = $this->configuration->ldapGroupDisplayName;
 		if ($displayName === '') {
 			$d = $this->configuration->getDefaults();
-			$this->applyFind('ldap_group_display_name',
-							 $d['ldap_group_display_name']);
+			$this->applyFind('ldapGroupDisplayName',
+							 $d['ldapGroupDisplayName']);
 		}
 		$filter = $this->composeLdapFilter(self::LFILTER_GROUP_LIST);
 
-		$this->applyFind('ldap_group_filter', $filter);
+		$this->applyFind('ldapGroupFilter', $filter);
 		return $this->result;
 	}
 
@@ -583,14 +583,14 @@ class Wizard extends LDAPUtility {
 		$displayName = $this->configuration->ldapUserDisplayName;
 		if ($displayName === '') {
 			$d = $this->configuration->getDefaults();
-			$this->applyFind('ldap_display_name', $d['ldap_display_name']);
+			$this->applyFind('ldapUserDisplayName', $d['ldapUserDisplayName']);
 		}
 		$filter = $this->composeLdapFilter(self::LFILTER_USER_LIST);
 		if (!$filter) {
 			throw new \Exception('Cannot create filter');
 		}
 
-		$this->applyFind('ldap_userlist_filter', $filter);
+		$this->applyFind('ldapUserFilter', $filter);
 		return $this->result;
 	}
 
@@ -612,7 +612,7 @@ class Wizard extends LDAPUtility {
 			throw new \Exception('Cannot create filter');
 		}
 
-		$this->applyFind('ldap_login_filter', $filter);
+		$this->applyFind('ldapLoginFilter', $filter);
 		return $this->result;
 	}
 
@@ -697,7 +697,7 @@ class Wizard extends LDAPUtility {
 				];
 				$this->configuration->setConfiguration($config);
 				\OCP\Util::writeLog('user_ldap', 'Wiz: detected Port ' . $p, \OCP\Util::DEBUG);
-				$this->result->addChange('ldap_port', $p);
+				$this->result->addChange('ldapPort', $p);
 				return $this->result;
 			}
 		}
@@ -723,7 +723,7 @@ class Wizard extends LDAPUtility {
 		if ($i !== false) {
 			$base = \substr($this->configuration->ldapAgentName, $i);
 			if ($this->testBaseDN($base)) {
-				$this->applyFind('ldap_base', $base);
+				$this->applyFind('ldapBase', $base);
 				return $this->result;
 			}
 		}
@@ -741,7 +741,7 @@ class Wizard extends LDAPUtility {
 		while (\count($dparts) > 0) {
 			$base2 = 'dc=' . \implode(',dc=', $dparts);
 			if ($base !== $base2 && $this->testBaseDN($base2)) {
-				$this->applyFind('ldap_base', $base2);
+				$this->applyFind('ldapBase', $base2);
 				return $this->result;
 			}
 			\array_shift($dparts);
@@ -775,8 +775,8 @@ class Wizard extends LDAPUtility {
 		if (\is_array($hostInfo) && isset($hostInfo['port'])) {
 			$port = $hostInfo['port'];
 			$host = \str_replace(':'.$port, '', $host);
-			$this->applyFind('ldap_host', $host);
-			$this->applyFind('ldap_port', $port);
+			$this->applyFind('ldapHost', $host);
+			$this->applyFind('ldapPort', $port);
 		}
 	}
 

--- a/tests/integration/Lib/IntegrationBackupServer.php
+++ b/tests/integration/Lib/IntegrationBackupServer.php
@@ -45,8 +45,8 @@ class IntegrationBackupServer extends AbstractIntegrationTest {
 		$this->connection->setConfiguration([
 			'ldapHost' => 'qwertz.uiop',
 			'ldapPort' => '32123',
-			'ldap_backup_host' => $originalHost,
-			'ldap_backup_port' => $originalPort,
+			'ldapBackupHost' => $originalHost,
+			'ldapBackupPort' => $originalPort,
 		]);
 	}
 
@@ -80,8 +80,8 @@ class IntegrationBackupServer extends AbstractIntegrationTest {
 		$this->initConnection();
 		try {
 			$this->connection->setConfiguration([
-				'ldap_backup_host' => 'qwertz.uiop',
-				'ldap_backup_port' => '32123',
+				'ldapBackupHost' => 'qwertz.uiop',
+				'ldapBackupPort' => '32123',
 			]);
 			$this->connection->getConnectionResource();
 		} catch (ServerNotAvailableException $e) {
@@ -101,8 +101,8 @@ class IntegrationBackupServer extends AbstractIntegrationTest {
 		$this->initConnection();
 		try {
 			$this->connection->setConfiguration([
-				'ldap_backup_host' => '',
-				'ldap_backup_port' => '',
+				'ldapBackupHost' => '',
+				'ldapBackupPort' => '',
 			]);
 			$this->connection->getConnectionResource();
 		} catch (ServerNotAvailableException $e) {

--- a/tests/integration/Lib/IntegrationTestBackupServer.php
+++ b/tests/integration/Lib/IntegrationTestBackupServer.php
@@ -45,8 +45,8 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 		$this->connection->setConfiguration([
 			'ldapHost' => 'qwertz.uiop',
 			'ldapPort' => '32123',
-			'ldap_backup_host' => $originalHost,
-			'ldap_backup_port' => $originalPort,
+			'ldapBackupHost' => $originalHost,
+			'ldapBackupPort' => $originalPort,
 		]);
 	}
 
@@ -80,8 +80,8 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 		$this->initConnection();
 		try {
 			$this->connection->setConfiguration([
-				'ldap_backup_host' => 'qwertz.uiop',
-				'ldap_backup_port' => '32123',
+				'ldapBackupHost' => 'qwertz.uiop',
+				'ldapBackupPort' => '32123',
 			]);
 			$this->connection->getConnectionResource();
 		} catch (\OC\ServerNotAvailableException $e) {
@@ -101,8 +101,8 @@ class IntegrationTestBackupServer extends AbstractIntegrationTest {
 		$this->initConnection();
 		try {
 			$this->connection->setConfiguration([
-				'ldap_backup_host' => '',
-				'ldap_backup_port' => '',
+				'ldapBackupHost' => '',
+				'ldapBackupPort' => '',
 			]);
 			$this->connection->getConnectionResource();
 		} catch (\OC\ServerNotAvailableException $e) {

--- a/tests/unit/Controller/ConfigurationControllerTest.php
+++ b/tests/unit/Controller/ConfigurationControllerTest.php
@@ -166,8 +166,8 @@ class ConfigurationControllerTest extends TestCase {
 		$this->assertArraySubset([
 			'status' => 'success',
 			'configuration' => [
-				'ldap_host' => 'example.org',
-				'ldap_agent_password' => '**PASSWORD SET**'
+				'ldapHost' => 'example.org',
+				'ldapAgentPassword' => '**PASSWORD SET**'
 			]
 		], $data, true);
 	}

--- a/tests/unit/WizardTest.php
+++ b/tests/unit/WizardTest.php
@@ -293,7 +293,7 @@ class WizardTest extends \Test\TestCase {
 
 		$result = $this->wizard->detectEmailAttribute()->getResultArray();
 		$this->assertSame('mailPrimaryAddress',
-			$result['changes']['ldap_email_attr']);
+			$result['changes']['ldapEmailAttribute']);
 	}
 
 	public function testDetectEmailAttributeFind() {
@@ -332,7 +332,7 @@ class WizardTest extends \Test\TestCase {
 		$this->wizard = new Wizard($this->ldap, $this->configuration, $this->access, $this->l10n);
 		$result = $this->wizard->detectEmailAttribute()->getResultArray();
 		$this->assertSame('mailPrimaryAddress',
-			$result['changes']['ldap_email_attr']);
+			$result['changes']['ldapEmailAttribute']);
 	}
 
 	public function testDetectEmailAttributeFindNothing() {


### PR DESCRIPTION
This is a followup for https://github.com/owncloud/user_ldap/pull/393
We can encode arrays directly to json and do not use CR/LF as a separator. 

Before
```
"ldapBase":"dc=firstbase,dc=com/ndc=secondbase,dc=com"
```

After 
```
"ldapBase":"[
"dc=firstbase,dc=com",
"dc=secondbase,dc=com"
]
```

Note that the part splitting these values when they are coming from the wizard is still in place.

Additionally, the config options notation has been unified to pascalCase.
E.g. 
before **$configuration->ldap_host** or **$configuration->ldapHost** could be used so the code was a bit messy
This PR removes **$configuration->ldap_host** notation support and makes the frontend responsible for underscore <-> pascalCase transformation.