### PR TITLE
Split long-running api acceptance suites

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -953,6 +953,16 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiAuthOcs
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiCapabilities
 
     - TEST_SUITE: core-api-acceptance
@@ -1023,6 +1033,16 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiShareManagementBasic
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareOperations
 
     - TEST_SUITE: core-api-acceptance
@@ -1074,6 +1094,16 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavLocks
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiWebdavLocks2
 
     - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-master-qa
@@ -1135,6 +1165,16 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiAuthOcs
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiCapabilities
 
     - TEST_SUITE: core-api-acceptance
@@ -1205,6 +1245,16 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiShareManagementBasic
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
       BEHAT_SUITE: apiShareOperations
 
     - TEST_SUITE: core-api-acceptance
@@ -1256,6 +1306,16 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
       BEHAT_SUITE: apiWebdavLocks
+
+    - TEST_SUITE: core-api-acceptance
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      BEHAT_SUITE: apiWebdavLocks2
 
     - TEST_SUITE: core-api-acceptance
       OC_VERSION: daily-stable10-qa

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -45,6 +45,15 @@ default:
         - FeatureContext: *common_feature_context_params
         - CorsContext:
 
+    apiAuthOcs:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiAuthOcs'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - CorsContext:
+
     apiCapabilities:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiCapabilities'
@@ -115,6 +124,17 @@ default:
         - TrashbinContext:
         - WebDavPropertiesContext:
 
+    apiShareManagementBasic:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiShareManagementBasic'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - PublicWebDavContext:
+        - TrashbinContext:
+        - WebDavPropertiesContext:
+
     apiShareOperations:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiShareOperations'
@@ -167,6 +187,17 @@ default:
     apiWebdavLocks:
       paths:
         - '%paths.base%/../../../../../tests/acceptance/features/apiWebdavLocks'
+      context: *common_ldap_suite_context
+      contexts:
+        - UserLdapGeneralContext:
+        - FeatureContext: *common_feature_context_params
+        - PublicWebDavContext:
+        - WebDavLockingContext:
+        - WebDavPropertiesContext:
+
+    apiWebdavLocks2:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/apiWebdavLocks2'
       context: *common_ldap_suite_context
       contexts:
         - UserLdapGeneralContext:


### PR DESCRIPTION
Fixes #413 

Similar to https://github.com/owncloud/core/pull/35170

Add CI for:
```
apiAuthOcs
apiShareManagementBasic
apiWebdavLocks2
```
Note, we do not run the core provisioning suites here, so there is no need to add the new `apiProvisioningGroups-v1` and `apiProvisioningGroups-v2` suites.
