### PR TITLE
Fix wizard by translating keys (missing code)

### DIFF
--- a/js/wizard/configModel.js
+++ b/js/wizard/configModel.js
@@ -205,6 +205,14 @@ OCA = OCA || {};
 					});
 					result['changes'] = changes;
 				}
+				if (result['options']) {
+					var options = {};
+					$.each(result['options'], function(key, value) {
+						key = model.mappings[key] || key;
+						options[key] = value;
+					});
+					result['options'] = options;
+				}
 				callback(model, detector, result);
 			});
 		},


### PR DESCRIPTION
Previous commit from master (16f229a8fb6515f86bdd9bdbd99d28e0fadd4940) has the wizard broken due to the mappings introduced in 7277bf0d6ac92be60bb84520c0c358187218b226 .
This commit fixes the issue. The wizard works again now.