### PR TITLE
Include port only if there is port

### DIFF
--- a/lib/LDAP.php
+++ b/lib/LDAP.php
@@ -54,7 +54,9 @@ class LDAP implements ILDAPWrapper {
 		}
 		if (\strpos($host, ':', \strpos($host, '://') + 1) === false) {
 			//ldap_connect ignores port parameter when URLs are passed
-			$host .= ':' . $port;
+			if ($port !== '') {
+				$host .= ':' . $port;
+			}
 		}
 		return $this->invokeLDAPMethod('connect', $host);
 	}


### PR DESCRIPTION
Prevent failure with the backup server if no port is suplied.

Related to https://github.com/owncloud/enterprise/issues/2756