### PR TITLE
add emoji group in the ldif file to be imported at start of tests

### DIFF
--- a/tests/acceptance/config/ldap-users.ldif
+++ b/tests/acceptance/config/ldap-users.ldif
@@ -102,6 +102,14 @@ gidnumber: 500
 objectclass: top
 objectclass: posixGroup
 
+dn: cn=😀 😁,ou=TestGroups,dc=owncloud,dc=com
+cn: 😀 😁
+memberuid: user1
+memberuid: user2
+gidnumber: 500
+objectclass: top
+objectclass: posixGroup
+
 dn: uid=regularuser,ou=TestUsers,dc=owncloud,dc=com
 cn: Regular User
 sn: User


### PR DESCRIPTION
This group are now used in core tests, so easy to add them here so that the same tests will run in user_ldap