### PR TITLE
Remove no longer existing job from appinfo

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -30,10 +30,6 @@ More information is available in the [LDAP User and Group Backend documentation]
 
 	<namespace>User_LDAP</namespace>
 
-	<background-jobs>
-		<job>OCA\User_LDAP\Jobs\UpdateGroups</job>
-	</background-jobs>
-
 	<settings>
 		<admin>OCA\User_LDAP\AdminPanel</admin>
 	</settings>


### PR DESCRIPTION
Fixes https://github.com/owncloud/core/issues/35345

https://github.com/owncloud/user_ldap/pull/248 removed the job but left an entry in appinfo