### PR TITLE
split core webUI tests into two parts

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -246,7 +246,7 @@ pipeline:
       - TEST_SERVER_FED_URL=http://federated
       - PLATFORM=Linux
       - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=webUICore
+      - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
       - make test-acceptance-core-webui
     when:
@@ -1039,6 +1039,20 @@ matrix:
       NEED_SELENIUM: true
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
+      BEHAT_SUITE: webUICore1
+
+    - TEST_SUITE: core-web-acceptance
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.1
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SELENIUM: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      BEHAT_SUITE: webUICore2
 
     - TEST_SUITE: core-web-acceptance
       OC_VERSION: daily-stable10-qa
@@ -1051,6 +1065,20 @@ matrix:
       NEED_SELENIUM: true
       USE_FEDERATED_SERVER: true
       FEDERATION_OC_VERSION: daily-stable10-qa
+      BEHAT_SUITE: webUICore1
+
+    - TEST_SUITE: core-web-acceptance
+      OC_VERSION: daily-stable10-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      PHP_VERSION: 7.0
+      NEED_SERVER: true
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+      NEED_SELENIUM: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
+      BEHAT_SUITE: webUICore2
 
     #acceptance tests - CLI tests from core
     # with php 7.1 and core master

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -3,16 +3,27 @@ default:
     '': '%paths.base%/../features/bootstrap'
 
   suites:
-    webUICore:
+    webUICore1:
       paths:
-        - '%paths.base%/../../../../../tests/acceptance/features'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIAdminSettings'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIComments'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUICreateDelete'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIFavorites'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIFiles'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUILogin'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIMoveFilesFolders'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIPersonalSettings'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIRenameFiles'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIRenameFolders'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIRestrictSharing'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAcceptShares'
       context: &common_ldap_suite_context
         parameters:
           ldapAdminPassword: admin
           ldapUsersOU: TestUsers
           ldapGroupsOU: TestGroups
           ldapInitialUserFilePath: /../../config/ldap-users.ldif
-      contexts:
+      contexts: &common_webui_core_contexts
         - UserLdapGeneralContext:
         - FeatureContext: &common_feature_context_params
             baseUrl:  http://localhost:8080
@@ -31,6 +42,22 @@ default:
         - WebUISearchContext:
         - WebUISharingContext:
         - WebUIUserContext:
+
+    webUICore2:
+      paths:
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAutocompletion'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingExternal'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalGroups'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingNotifications'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingPublic'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITags'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITrashbin'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIUpload'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLockProtection'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLocks'
+      context: *common_ldap_suite_context
+      contexts: *common_webui_core_contexts
 
     apiAuth:
       paths:


### PR DESCRIPTION
## Description
Split core webUI tests into two parts to reduce drone job time.

## Related Issue
https://github.com/owncloud/user_ldap/issues/422

## Motivation and Context

## How Has This Been Tested?
🤖

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link>