### PR TITLE
Add WebUIAdminSharingSettingsContext for acceptance tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,7 +61,8 @@ pipeline:
       - php occ a:l
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 0
+      - php occ log:manage --level 2
+      - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
       - php occ config:list
     when:
       matrix:
@@ -114,7 +115,7 @@ pipeline:
       - php occ a:l
       - php occ config:system:set trusted_domains 1 --value=server
       - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 0
+      - php occ log:manage --level 2
       - php occ config:system:set --value true --type boolean integrity.check.disabled
     when:
       matrix:
@@ -193,6 +194,8 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-api
     when:
@@ -207,6 +210,8 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-cli
     when:
@@ -225,6 +230,8 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-webui
     when:
@@ -239,6 +246,8 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-core-api
     when:
@@ -253,6 +262,8 @@ pipeline:
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-core-cli
     when:
@@ -267,11 +278,12 @@ pipeline:
       - SELENIUM_HOST=selenium
       - SELENIUM_PORT=4444
       - TEST_SERVER_URL=http://server
-      - TEST_SERVER_FED_URL=http://federated
       - PLATFORM=Linux
       - TEST_EXTERNAL_USER_BACKENDS=true
       - BEHAT_SUITE=${BEHAT_SUITE}
     commands:
+      - touch /var/www/owncloud/saved-settings.sh
+      - . /var/www/owncloud/saved-settings.sh
       - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
       - make test-acceptance-core-webui
     when:
@@ -1188,6 +1200,8 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       BEHAT_SUITE: apiFederation
 
     - TEST_SUITE: core-api-acceptance
@@ -1420,6 +1434,8 @@ matrix:
       NEED_SERVER: true
       NEED_CORE: true
       NEED_INSTALL_APP: true
+      USE_FEDERATED_SERVER: true
+      FEDERATION_OC_VERSION: daily-stable10-qa
       BEHAT_SUITE: apiFederation
 
     - TEST_SUITE: core-api-acceptance

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -33,6 +33,7 @@ default:
             regularUserPassword: 123456
         - EmailContext:
         - FederationContext:
+        - WebUIAdminSharingSettingsContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:
         - WebUILoginContext:

--- a/tests/acceptance/features/apiUserLDAPSharing/sharingLocalUserLdapUser.feature
+++ b/tests/acceptance/features/apiUserLDAPSharing/sharingLocalUserLdapUser.feature
@@ -28,7 +28,7 @@ Feature: Sharing between local and LDAP users
     And the content of file "/PARENT/parent.txt" for user "user0" should be "changed file"
 
   Scenario: Share a folder from an LDAP user to a local user read only
-   Given user "user0" has shared folder "/PARENT" with user "local-user" with permissions read
+   Given user "user0" has shared folder "/PARENT" with user "local-user" with permissions "read"
    When user "local-user" uploads file with content "new file" to "PARENT (2)/new-file.txt" using the WebDAV API
    Then the HTTP status code should be "403"
    And as "user0" file "/PARENT/new-file.txt" should not exist
@@ -56,7 +56,7 @@ Feature: Sharing between local and LDAP users
     And the content of file "/PARENT/parent.txt" for user "local-user" should be "changed file"
 
   Scenario: Share a folder from a local user to an LDAP user without write permissions
-   Given user "local-user" has shared folder "/PARENT" with user "user0" with permissions read
+   Given user "local-user" has shared folder "/PARENT" with user "user0" with permissions "read"
    When user "user0" uploads file with content "new file" to "PARENT (2)/new-file.txt" using the WebDAV API
    Then the HTTP status code should be "403"
    And as "local-user" file "/PARENT/new-file.txt" should not exist


### PR DESCRIPTION
Fixes issue #438 

The 2nd commit fixes https://drone.owncloud.com/owncloud/user_ldap/1705/1025
```
--- Failed scenarios:

    /var/www/owncloud/server/tests/acceptance/features/apiFederation/federated.feature:555
    /var/www/owncloud/server/tests/acceptance/features/apiFederation/federated.feature:575

60 scenarios (58 passed, 2 failed)
725 steps (721 passed, 2 failed, 2 skipped)
```
by properly starting a separate federated server during drone testing. That makes the trusted server tests work properly.