### PR TITLE
Use only 1 var in when matrix of drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -154,7 +154,6 @@ pipeline:
       - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
     when:
       matrix:
-        NEED_SERVER: true
         USE_LDAPS: true
 
   ldap-check-config:


### PR DESCRIPTION
The new drone tries to auto-convert the old drone format. It seems that when there are multiple variables mentioned in the `when` section of a step, it is doing something in the auto-conversion that causes:

`linter: duplicate step names`

I guess that it might be putting the step twice into the converted matrix.

The changes in this PR work-around the "feature".