### PR TITLE
add a catch blog for expected exceptions in password check

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -528,7 +528,7 @@ class Connection extends LDAPUtility {
 					}
 					Util::writeLog('user_ldap',
 						'Bind failed: ' . $this->getLDAP()->errno($this->ldapConnectionRes) . ': ' . $this->getLDAP()->error($this->ldapConnectionRes),
-						Util::DEBUG); // log only in debug mod because this is triggered by wrong passwords
+						Util::DEBUG);
 					throw new BindFailedException();
 				}
 			} catch (ServerNotAvailableException $e) {
@@ -574,6 +574,9 @@ class Connection extends LDAPUtility {
 	}
 
 	/**
+	 * This method will perform some setup required to connect to the LDAP server,
+	 * but it won't connect to the LDAP server unless ldap_start_tls is activated
+	 *
 	 * @param string $host
 	 * @param string $port
 	 * @return bool

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -528,6 +528,7 @@ class Manager {
 	/**
 	 * @param string $name
 	 * @param string $password
+	 * @throws ServerNotAvailableException
 	 * @return bool
 	 */
 	public function areCredentialsValid($name, $password) {

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -138,16 +138,15 @@ class User_LDAP implements IUserBackend, UserInterface {
 	public function checkPassword($uid, $password) {
 		try {
 			$userEntry = $this->userManager->getLDAPUserByLoginName($uid);
+			//are the credentials OK?
+			if (!$this->userManager->areCredentialsValid($userEntry->getDN(), $password)) {
+				return false;
+			}
 		} catch (DoesNotExistOnLDAPException $e) {
 			return false;
 		} catch (\Exception $e) {
 			// Something more serious than not found occured
 			\OC::$server->getLogger()->logException($e, ['app' => 'user_ldap']);
-			return false;
-		}
-		
-		//are the credentials OK?
-		if (!$this->userManager->areCredentialsValid($userEntry->getDN(), $password)) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/owncloud/enterprise/issues/3496

This PR adds a catch blog for expected exceptions in password check, to not show internal error for users.

`ldap_connect` only applies syntactic checks for given parameters, does not contact the server. In our implementation, as far as I see, we assume the server will be available if a request passes from this check. I clarified this situation with comment lines for further usages.