### PR TITLE
drone notify on failure

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1346,6 +1346,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}

--- a/.drone.yml
+++ b/.drone.yml
@@ -16048,6 +16048,9 @@ trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-php7.0-sqlite


### PR DESCRIPTION
Like https://github.com/owncloud/activity/pull/794

If a nightly build has failure, then nothing is being reported in rocketchat, because the pipelines stop once there is a failure. So the notify pipeline is never executed.

Adjust so that the notify pipeline will execute on both success and failure.