### PR TITLE
Balance webUI core tests

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -17,6 +17,16 @@ default:
         - '%paths.base%/../../../../../tests/acceptance/features/webUIRenameFolders'
         - '%paths.base%/../../../../../tests/acceptance/features/webUIRestrictSharing'
         - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAcceptShares'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAutocompletion'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalGroups'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingNotifications'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingPublic'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITags'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITrashbin'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIUpload'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLockProtection'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLocks'
       context: &common_ldap_suite_context
         parameters:
           ldapAdminPassword: admin
@@ -46,17 +56,7 @@ default:
 
     webUICore2:
       paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAutocompletion'
         - '%paths.base%/../../../../../tests/acceptance/features/webUISharingExternal'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalGroups'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingNotifications'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingPublic'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUITags'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUITrashbin'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIUpload'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLockProtection'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLocks'
       context: *common_ldap_suite_context
       contexts: *common_webui_core_contexts
 


### PR DESCRIPTION
Part of issue #422 

The second part of the core webUI tests had 42 scenarios, the first part had only 8 scenarios.

`webUISharingExternal` has about 30 scenarios enabled for running on `user_ldap` - so leave that as the only suite in `webUICore2`

This will reduce a bit the time taken for the `webUICore2`, which will help to (sometimes) reduce the overall elapsed time for the `user_ldap` drone runs.
