### PR TITLE
Add WebDavPropertiesContext to apiWebdavOperations

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -280,6 +280,7 @@ default:
         - SearchContext:
         - OccContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     apiWebdavProperties:
       paths:


### PR DESCRIPTION
Issue #463 

core PR https://github.com/owncloud/core/pull/36321 added core test scenarios that need `WebDavPropertiesContext`

Add it here in `user_ldap` also, so that core CI can pass.