### PR TITLE
Drone for 0.14.0 branch

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1346,6 +1346,10 @@ def notify():
 		'trigger': {
 			'ref': [
 				'refs/tags/**'
+			],
+			'status': [
+				'success',
+				'failure'
 			]
 		}
 	}

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -13,7 +13,7 @@ config = {
 
 	'phpstan': False,
 
-	'phan': True,
+	'phan': False,
 
 	'javascript': False,
 

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -1,0 +1,1699 @@
+config = {
+	'app': 'user_ldap',
+	'rocketchat': {
+		'channel': 'builds',
+		'from_secret': 'private_rocketchat'
+	},
+
+	'branches': [
+		'master'
+	],
+
+	'codestyle': True,
+
+	'phpstan': False,
+
+	'phan': True,
+
+	'javascript': False,
+
+	'phpunit': {
+		'allDatabases' : {
+			'phpVersions': [
+				'7.0',
+			]
+		},
+		'reducedDatabases' : {
+			'phpVersions': [
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+			'databases': [
+				'mysql:5.7',
+				'postgres:9.4',
+				'oracle',
+			],
+			'coverage': False
+		},
+	},
+
+	'acceptance': {
+		'api-with-core-master-mysql': {
+			'suites': [
+				'apiProvisioningLDAP',
+				'apiUserLDAP',
+				'apiUserLDAPConnection',
+				'apiUserLDAPSharing',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.0',
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+		},
+		'api-with-core-master-other-db': {
+			'suites': [
+				'apiProvisioningLDAP',
+				'apiUserLDAP',
+				'apiUserLDAPConnection',
+				'apiUserLDAPSharing',
+			],
+			'databases': [
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'api-with-core-latest': {
+			'suites': [
+				'apiProvisioningLDAP',
+				'apiUserLDAP',
+				'apiUserLDAPConnection',
+				'apiUserLDAPSharing',
+			],
+			'databases': [
+				'mysql:5.7',
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'api-with-ldaps': {
+			'suites': {
+				'apiProvisioningLDAP': 'apiProvisioningLDAPS',
+				'apiUserLDAP': 'apiUserLDAPS',
+				'apiUserLDAPConnection': 'apiUserLDAPConnectionS',
+				'apiUserLDAPSharing': 'apiUserLDAPSharingS',
+			},
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:set-config LDAPTestId ldapPort "636"',
+						'php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+		'cli-with-core-master-mysql': {
+			'suites': [
+				'cliProvisioning',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.0',
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+		},
+		'cli-with-core-master-other-db': {
+			'suites': [
+				'cliProvisioning',
+			],
+			'databases': [
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'cli-with-core-latest': {
+			'suites': [
+				'cliProvisioning',
+			],
+			'databases': [
+				'mysql:5.7',
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'cli-with-ldaps': {
+			'suites': {
+				'cliProvisioning': 'cliProvisioningLDAPS',
+			},
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:set-config LDAPTestId ldapPort "636"',
+						'php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+		'webUI-with-core-master-mysql': {
+			'suites': [
+				'webUIUserLDAP',
+				'webUIProvisioning',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.0',
+				'7.1',
+				'7.2',
+				'7.3',
+			],
+		},
+		'webUI-with-core-master-other-db': {
+			'suites': [
+				'webUIUserLDAP',
+				'webUIProvisioning',
+			],
+			'databases': [
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'webUI-with-core-latest': {
+			'suites': [
+				'webUIUserLDAP',
+				'webUIProvisioning',
+			],
+			'databases': [
+				'mysql:5.7',
+				'postgres:9.4',
+				'oracle',
+			],
+			'servers': [
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+		},
+		'webUI-with-ldaps': {
+			'suites': {
+				'webUIUserLDAP': 'webUIUserLDAPS',
+				'webUIProvisioning': 'webUIProvisioningS',
+			},
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+				'latest',
+			],
+			'phpVersions': [
+				'7.2',
+			],
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:set-config LDAPTestId ldapPort "636"',
+						'php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+		'core-api-acceptance': {
+			'suites': [
+				'apiAuth',
+				'apiAuthOcs',
+				'apiCapabilities',
+				'apiComments',
+				'apiFavorites',
+				'apiMain',
+				'apiSharees',
+				'apiShareManagement',
+				'apiShareManagementBasic',
+				'apiShareOperations',
+				'apiShareReshare',
+				'apiShareUpdate',
+				'apiSharingNotifications',
+				'apiTags',
+				'apiTrashbin',
+				'apiVersions',
+				'apiWebdavLocks',
+				'apiWebdavLocks2',
+				'apiWebdavMove',
+				'apiWebdavOperations',
+				'apiWebdavProperties',
+				'apiWebdavUpload',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.1',
+			],
+			'runCoreTests': True,
+		},
+		'core-api-federation': {
+			'suites': [
+				'apiFederation',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.1',
+			],
+			'runCoreTests': True,
+			'federatedServerNeeded': True,
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				},
+				{
+					'name': 'configure-app-on-federated-server',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/federated',
+						'php occ market:install user_ldap',
+						'bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+		'core-cli-acceptance': {
+			'suites': [
+				'cliTrashbin',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.1',
+			],
+			'runCoreTests': True,
+		},
+		'core-webui-acceptance': {
+			'suites': [
+				'webUICore1',
+				'webUICore2',
+			],
+			'databases': [
+				'mysql:5.7',
+			],
+			'servers': [
+				'daily-master-qa',
+			],
+			'phpVersions': [
+				'7.1',
+			],
+			'runCoreTests': True,
+			'federatedServerNeeded': True,
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				},
+				{
+					'name': 'configure-app-on-federated-server',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/federated',
+						'php occ market:install user_ldap',
+						'bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+	},
+
+	'defaults': {
+		'acceptance': {
+			'ldapNeeded': True,
+			'extraSetup': [
+				{
+					'name': 'configure-app',
+					'image': 'owncloudci/php:7.0',
+					'pull': 'always',
+					'commands': [
+						'cd /var/www/owncloud/server',
+						'bash ./apps/user_ldap/tests/acceptance/setConfig.sh',
+						'php occ ldap:show-config',
+						'php occ ldap:test-config "LDAPTestId"',
+						'php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove',
+						'php occ user:list',
+					]
+				}
+			],
+		},
+	}
+}
+
+def main(ctx):
+	before = beforePipelines()
+
+	stages = stagePipelines()
+	if (stages == False):
+		print('Errors detected. Review messages above.')
+		return []
+
+	dependsOn(before, stages)
+
+	after = afterPipelines()
+	dependsOn(stages, after)
+
+	return before + stages + after
+
+def beforePipelines():
+	return codestyle() + jscodestyle() + phpstan() + phan()
+
+def stagePipelines():
+	buildPipelines = build()
+	jsPipelines = javascript()
+	phpunitPipelines = phptests('phpunit')
+	phpintegrationPipelines = phptests('phpintegration')
+	acceptancePipelines = acceptance()
+	if (buildPipelines == False) or (jsPipelines == False) or (phpunitPipelines == False) or (phpintegrationPipelines == False) or (acceptancePipelines == False):
+		return False
+
+	return buildPipelines + jsPipelines + phpunitPipelines + phpintegrationPipelines + acceptancePipelines
+
+def afterPipelines():
+	return [
+		notify()
+	]
+
+def codestyle():
+	pipelines = []
+
+	if 'codestyle' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0'],
+	}
+
+	if 'defaults' in config:
+		if 'codestyle' in config['defaults']:
+			for item in config['defaults']['codestyle']:
+				default[item] = config['defaults']['codestyle'][item]
+
+	codestyleConfig = config['codestyle']
+
+	if type(codestyleConfig) == "bool":
+		if codestyleConfig:
+			# the config has 'codestyle' true, so specify an empty dict that will get the defaults
+			codestyleConfig = {}
+		else:
+			return pipelines
+
+	if len(codestyleConfig) == 0:
+		# 'codestyle' is an empty dict, so specify a single section that will get the defaults
+		codestyleConfig = {'doDefault': {}}
+
+	for category, matrix in codestyleConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'coding-standard-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps': [
+					{
+						'name': 'coding-standard',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-style'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def jscodestyle():
+	pipelines = []
+
+	if 'jscodestyle' not in config:
+		return pipelines
+
+	if type(config['jscodestyle']) == "bool":
+		if not config['jscodestyle']:
+			return pipelines
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'coding-standard-js',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps': [
+			{
+				'name': 'coding-standard-js',
+				'image': 'owncloudci/php:7.2',
+				'pull': 'always',
+				'commands': [
+					'make test-js-style'
+				]
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	pipelines.append(result)
+
+	return pipelines
+
+def phpstan():
+	pipelines = []
+
+	if 'phpstan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.2'],
+		'logLevel': '2',
+	}
+
+	if 'defaults' in config:
+		if 'phpstan' in config['defaults']:
+			for item in config['defaults']['phpstan']:
+				default[item] = config['defaults']['phpstan'][item]
+
+	phpstanConfig = config['phpstan']
+
+	if type(phpstanConfig) == "bool":
+		if phpstanConfig:
+			# the config has 'phpstan' true, so specify an empty dict that will get the defaults
+			phpstanConfig = {}
+		else:
+			return pipelines
+
+	if len(phpstanConfig) == 0:
+		# 'phpstan' is an empty dict, so specify a single section that will get the defaults
+		phpstanConfig = {'doDefault': {}}
+
+	for category, matrix in phpstanConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'phpstan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps':
+					installCore('daily-master-qa', 'sqlite', False) +
+					installApp(phpVersion) +
+					setupServerAndApp(phpVersion, params['logLevel']) +
+				[
+					{
+						'name': 'phpstan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phpstan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def phan():
+	pipelines = []
+
+	if 'phan' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+	}
+
+	if 'defaults' in config:
+		if 'phan' in config['defaults']:
+			for item in config['defaults']['phan']:
+				default[item] = config['defaults']['phan'][item]
+
+	phanConfig = config['phan']
+
+	if type(phanConfig) == "bool":
+		if phanConfig:
+			# the config has 'phan' true, so specify an empty dict that will get the defaults
+			phanConfig = {}
+		else:
+			return pipelines
+
+	if len(phanConfig) == 0:
+		# 'phan' is an empty dict, so specify a single section that will get the defaults
+		phanConfig = {'doDefault': {}}
+
+	for category, matrix in phanConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		for phpVersion in params['phpVersions']:
+			name = 'phan-php%s' % phpVersion
+
+			result = {
+				'kind': 'pipeline',
+				'type': 'docker',
+				'name': name,
+				'workspace' : {
+					'base': '/var/www/owncloud',
+					'path': 'server/apps/%s' % config['app']
+				},
+				'steps':
+					installCore('daily-master-qa', 'sqlite', False) +
+				[
+					{
+						'name': 'phan',
+						'image': 'owncloudci/php:%s' % phpVersion,
+						'pull': 'always',
+						'commands': [
+							'make test-php-phan'
+						]
+					}
+				],
+				'depends_on': [],
+				'trigger': {
+					'ref': [
+						'refs/pull/**',
+						'refs/tags/**'
+					]
+				}
+			}
+
+			for branch in config['branches']:
+				result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+			pipelines.append(result)
+
+	return pipelines
+
+def build():
+	pipelines = []
+
+	if 'build' not in config:
+		return pipelines
+
+	default = {
+		'phpVersions': ['7.0'],
+		'commands': [
+			'make dist'
+		],
+		'extraEnvironment': {},
+		'configureTarOnTag': False,
+	}
+
+	if 'defaults' in config:
+		if 'build' in config['defaults']:
+			for item in config['defaults']['build']:
+				default[item] = config['defaults']['build'][item]
+
+	matrix = config['build']
+
+	if type(matrix) == "bool":
+		if matrix:
+			# the config has 'build' true, so specify an empty dict that will get the defaults
+			matrix = {}
+		else:
+			return pipelines
+
+	params = {}
+	for item in default:
+		params[item] = matrix[item] if item in matrix else default[item]
+
+	for phpVersion in params['phpVersions']:
+		result = {
+			'kind': 'pipeline',
+			'type': 'docker',
+			'name': 'build',
+			'workspace' : {
+				'base': '/var/www/owncloud',
+				'path': 'server/apps/%s' % config['app']
+			},
+			'steps': [
+				{
+					'name': 'build',
+					'image': 'owncloudci/php:%s' % phpVersion,
+					'pull': 'always',
+					'environment': params['extraEnvironment'],
+					'commands': params['commands']
+				}
+			] + ([
+				{
+					'name': 'github_release',
+					'image': 'plugins/github-release',
+					'pull': 'always',
+					'settings': {
+						'checksum': 'sha256',
+						'file_exists': 'overwrite',
+						'files': 'build/dist/%s.tar.gz' % config['app'],
+						'prerelease': True,
+					},
+					'environment': {
+						'GITHUB_TOKEN': {
+							'from_secret': 'github_token'
+						},
+					},
+					'when': {
+						'event': [
+							'tag'
+						]
+					},
+				}
+			] if params['configureTarOnTag'] else []),
+			'depends_on': [],
+			'trigger': {
+				'ref': [
+					'refs/pull/**',
+					'refs/tags/**'
+				]
+			}
+		}
+
+		for branch in config['branches']:
+			result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+		pipelines.append(result)
+
+	return pipelines
+
+def javascript():
+	pipelines = []
+
+	if 'javascript' not in config:
+		return pipelines
+
+	default = {
+		'coverage': False,
+		'logLevel': '2',
+		'extraSetup': [],
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+	}
+
+	if 'defaults' in config:
+		if 'javascript' in config['defaults']:
+			for item in config['defaults']['javascript']:
+				default[item] = config['defaults']['javascript'][item]
+
+	matrix = config['javascript']
+
+	if type(matrix) == "bool":
+		if matrix:
+			# the config has 'javascript' true, so specify an empty dict that will get the defaults
+			matrix = {}
+		else:
+			return pipelines
+
+	params = {}
+	for item in default:
+		params[item] = matrix[item] if item in matrix else default[item]
+
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'javascript-tests',
+		'workspace' : {
+			'base': '/var/www/owncloud',
+			'path': 'server/apps/%s' % config['app']
+		},
+		'steps':
+			installCore('daily-master-qa', 'sqlite', False) +
+			installApp('7.0') +
+			setupServerAndApp('7.0', params['logLevel']) +
+			params['extraSetup'] +
+		[
+			{
+				'name': 'js-tests',
+				'image': 'owncloudci/php:7.0',
+				'pull': 'always',
+				'environment': params['extraEnvironment'],
+				'commands': params['extraCommandsBeforeTestRun'] + [
+					'make test-js'
+				]
+			}
+		],
+		'services': params['extraServices'],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/pull/**',
+				'refs/tags/**'
+			]
+		}
+	}
+
+	if params['coverage']:
+		result['steps'].append({
+			'name': 'codecov-js',
+			'image': 'plugins/codecov:2',
+			'pull': 'always',
+			'settings': {
+				'paths': [
+					'coverage/*.info',
+				],
+				'token': {
+					'from_secret': 'codecov_token'
+				}
+			}
+		})
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return [result]
+
+def phptests(testType):
+	pipelines = []
+
+	if testType not in config:
+		return pipelines
+
+	errorFound = False
+
+	default = {
+		'phpVersions': ['7.0', '7.1', '7.2', '7.3'],
+		'databases': [
+			'sqlite', 'mariadb:10.2', 'mysql:5.5', 'mysql:5.7', 'postgres:9.4', 'oracle'
+		],
+		'coverage': True,
+		'includeKeyInMatrixName': False,
+		'logLevel': '2',
+		'cephS3': False,
+		'scalityS3': False,
+		'extraSetup': [],
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+		'extraApps': {},
+	}
+
+	if 'defaults' in config:
+		if testType in config['defaults']:
+			for item in config['defaults'][testType]:
+				default[item] = config['defaults'][testType][item]
+
+	phptestConfig = config[testType]
+
+	if type(phptestConfig) == "bool":
+		if phptestConfig:
+			# the config has just True, so specify an empty dict that will get the defaults
+			phptestConfig = {}
+		else:
+			return pipelines
+
+	if len(phptestConfig) == 0:
+		# the PHP test config is an empty dict, so specify a single section that will get the defaults
+		phptestConfig = {'doDefault': {}}
+
+	for category, matrix in phptestConfig.items():
+		params = {}
+		for item in default:
+			params[item] = matrix[item] if item in matrix else default[item]
+
+		if ((config['app'] != 'files_primary_s3') and ((params['cephS3'] != False) or (params['scalityS3'] != False))):
+			# If we are not already 'files_primary_s3' and we need S3 storage, then install the 'files_primary_s3' app
+			extraAppsDict  = {
+				'files_primary_s3': 'composer install'
+			}
+			for app, command in params['extraApps'].items():
+				extraAppsDict[app] = command
+			params['extraApps'] = extraAppsDict
+
+		for phpVersion in params['phpVersions']:
+
+			if testType == 'phpunit':
+				if params['coverage']:
+					command = 'make test-php-unit-dbg'
+				else:
+					command = 'make test-php-unit'
+			else:
+				if params['coverage']:
+					command = 'make test-php-integration-dbg'
+				else:
+					command = 'make test-php-integration'
+
+			for db in params['databases']:
+				keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+				name = '%s%s-php%s-%s' % (testType, keyString, phpVersion, db.replace(":", ""))
+				maxLength = 50
+				nameLength = len(name)
+				if nameLength > maxLength:
+					print("Error: generated phpunit stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+					errorFound = True
+
+				result = {
+					'kind': 'pipeline',
+					'type': 'docker',
+					'name': name,
+					'workspace' : {
+						'base': '/var/www/owncloud',
+						'path': 'server/apps/%s' % config['app']
+					},
+					'steps':
+						installCore('daily-master-qa', db, False) +
+						installApp(phpVersion) +
+						installExtraApps(phpVersion, params['extraApps']) +
+						setupServerAndApp(phpVersion, params['logLevel']) +
+						setupCeph(params['cephS3']) +
+						setupScality(params['scalityS3']) +
+						params['extraSetup'] +
+					[
+						{
+							'name': '%s-tests' % testType,
+							'image': 'owncloudci/php:%s' % phpVersion,
+							'pull': 'always',
+							'environment': params['extraEnvironment'],
+							'commands': params['extraCommandsBeforeTestRun'] + [
+								command
+							]
+						}
+					],
+					'services':
+						databaseService(db) +
+						cephService(params['cephS3']) +
+						scalityService(params['scalityS3']) +
+						params['extraServices'],
+					'depends_on': [],
+					'trigger': {
+						'ref': [
+							'refs/pull/**',
+							'refs/tags/**'
+						]
+					}
+				}
+
+				if params['coverage']:
+					result['steps'].append({
+						'name': 'codecov-upload',
+						'image': 'plugins/codecov:2',
+						'pull': 'always',
+						'settings': {
+							'paths': [
+								'tests/output/clover.xml',
+							],
+							'token': {
+								'from_secret': 'codecov_token'
+							}
+						}
+					})
+
+				for branch in config['branches']:
+					result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+				pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines
+
+def acceptance():
+	pipelines = []
+
+	if 'acceptance' not in config:
+		return pipelines
+
+	if type(config['acceptance']) == "bool":
+		if not config['acceptance']:
+			return pipelines
+
+	errorFound = False
+
+	default = {
+		'servers': ['daily-master-qa', 'latest'],
+		'browsers': ['chrome'],
+		'phpVersions': ['7.0'],
+		'databases': ['mariadb:10.2'],
+		'federatedServerNeeded': False,
+		'filterTags': '',
+		'logLevel': '2',
+		'emailNeeded': False,
+		'ldapNeeded': False,
+		'cephS3': False,
+		'scalityS3': False,
+		'extraSetup': [],
+		'extraServices': [],
+		'extraEnvironment': {},
+		'extraCommandsBeforeTestRun': [],
+		'extraApps': {},
+		'useBundledApp': False,
+		'includeKeyInMatrixName': False,
+		'runAllSuites': False,
+		'runCoreTests': False,
+		'numberOfParts': 1,
+	}
+
+	if 'defaults' in config:
+		if 'acceptance' in config['defaults']:
+			for item in config['defaults']['acceptance']:
+				default[item] = config['defaults']['acceptance'][item]
+
+	for category, matrix in config['acceptance'].items():
+		if type(matrix['suites']) == "list":
+			suites = {}
+			for suite in matrix['suites']:
+				suites[suite] = suite
+		else:
+			suites = matrix['suites']
+
+		for suite, alternateSuiteName in suites.items():
+			isWebUI = suite.startswith('webUI')
+			isAPI = suite.startswith('api')
+			isCLI = suite.startswith('cli')
+
+			params = {}
+			for item in default:
+				params[item] = matrix[item] if item in matrix else default[item]
+
+			if isAPI or isCLI:
+				params['browsers'] = ['']
+
+			needObjectStore = (params['cephS3'] != False) or (params['scalityS3'] != False)
+
+			if ((config['app'] != 'files_primary_s3') and (needObjectStore)):
+				# If we are not already 'files_primary_s3' and we need S3 object storage, then install the 'files_primary_s3' app
+				extraAppsDict  = {
+					'files_primary_s3': 'composer install'
+				}
+				for app, command in params['extraApps'].items():
+					extraAppsDict[app] = command
+				params['extraApps'] = extraAppsDict
+
+			for server in params['servers']:
+				for browser in params['browsers']:
+					for phpVersion in params['phpVersions']:
+						for db in params['databases']:
+							for runPart in range(1, params['numberOfParts'] + 1):
+								name = 'unknown'
+
+								if isWebUI or isAPI or isCLI:
+									browserString = '' if browser == '' else '-' + browser
+									keyString = '-' + category if params['includeKeyInMatrixName'] else ''
+									partString = '' if params['numberOfParts'] == 1 else '-%d-%d' % (params['numberOfParts'], runPart)
+									name = '%s%s%s-%s%s-%s-php%s' % (alternateSuiteName, keyString, partString, server.replace('daily-', '').replace('-qa', ''), browserString, db.replace(':', ''), phpVersion)
+									maxLength = 50
+									nameLength = len(name)
+									if nameLength > maxLength:
+										print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+										errorFound = True
+
+								environment = {}
+								for env in params['extraEnvironment']:
+									environment[env] = params['extraEnvironment'][env]
+
+								environment['TEST_SERVER_URL'] = 'http://server'
+								environment['BEHAT_FILTER_TAGS'] = params['filterTags']
+
+								if (params['runAllSuites'] == False):
+									environment['BEHAT_SUITE'] = suite
+								else:
+									environment['DIVIDE_INTO_NUM_PARTS'] = params['numberOfParts']
+									environment['RUN_PART'] = runPart
+
+								if isWebUI:
+									environment['SELENIUM_HOST'] = 'selenium'
+									environment['SELENIUM_PORT'] = '4444'
+									environment['BROWSER'] = browser
+									environment['PLATFORM'] = 'Linux'
+									if (params['runCoreTests']):
+										makeParameter = 'test-acceptance-core-webui'
+									else:
+										makeParameter = 'test-acceptance-webui'
+
+								if isAPI:
+									if (params['runCoreTests']):
+										makeParameter = 'test-acceptance-core-api'
+									else:
+										makeParameter = 'test-acceptance-api'
+
+								if isCLI:
+									if (params['runCoreTests']):
+										makeParameter = 'test-acceptance-core-cli'
+									else:
+										makeParameter = 'test-acceptance-cli'
+
+								if params['emailNeeded']:
+									environment['MAILHOG_HOST'] = 'email'
+
+								if params['ldapNeeded']:
+									environment['TEST_EXTERNAL_USER_BACKENDS'] = True
+
+								if (needObjectStore):
+									environment['OC_TEST_ON_OBJECTSTORE'] = '1'
+									if (params['cephS3'] != False):
+										environment['S3_TYPE'] = 'ceph'
+									if (params['scalityS3'] != False):
+										environment['S3_TYPE'] = 'scality'
+
+								result = {
+									'kind': 'pipeline',
+									'type': 'docker',
+									'name': name,
+									'workspace' : {
+										'base': '/var/www/owncloud',
+										'path': 'testrunner/apps/%s' % config['app']
+									},
+									'steps':
+										installCore(server, db, params['useBundledApp']) +
+										installTestrunner(phpVersion, params['useBundledApp']) +
+									([
+										{
+											'name': 'install-federation',
+											'image': 'owncloudci/core',
+											'pull': 'always',
+											'settings': {
+												'version': server,
+												'core_path': '/var/www/owncloud/federated'
+											}
+										},
+										{
+											'name': 'configure-federation',
+											'image': 'owncloudci/php:%s' % phpVersion,
+											'pull': 'always',
+											'commands': [
+												'echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh',
+												'cd /var/www/owncloud/federated',
+												'php occ a:l',
+												'php occ a:e testing',
+												'php occ a:l',
+												'php occ config:system:set trusted_domains 1 --value=federated',
+												'php occ log:manage --level %s' % params['logLevel'],
+												'php occ config:list'
+											]
+										}
+									] + owncloudLog('federated') if params['federatedServerNeeded'] else []) +
+										installApp(phpVersion) +
+										installExtraApps(phpVersion, params['extraApps']) +
+										setupServerAndApp(phpVersion, params['logLevel']) +
+										owncloudLog('server') +
+										setupCeph(params['cephS3']) +
+										setupScality(params['scalityS3']) +
+										params['extraSetup'] +
+										fixPermissions(phpVersion, params['federatedServerNeeded']) +
+									[
+										({
+											'name': 'acceptance-tests',
+											'image': 'owncloudci/php:%s' % phpVersion,
+											'pull': 'always',
+											'environment': environment,
+											'commands': params['extraCommandsBeforeTestRun'] + [
+												'touch /var/www/owncloud/saved-settings.sh',
+												'. /var/www/owncloud/saved-settings.sh',
+												'make %s' % makeParameter
+											]
+										}),
+									],
+									'services':
+										databaseService(db) +
+										browserService(browser) +
+										emailService(params['emailNeeded']) +
+										ldapService(params['ldapNeeded']) +
+										cephService(params['cephS3']) +
+										scalityService(params['scalityS3']) +
+										params['extraServices'] +
+										owncloudService(server, phpVersion, 'server', '/var/www/owncloud/server', False) +
+										(owncloudService(server, phpVersion, 'federated', '/var/www/owncloud/federated', False) if params['federatedServerNeeded'] else []),
+									'depends_on': [],
+									'trigger': {
+										'ref': [
+											'refs/pull/**',
+											'refs/tags/**'
+										]
+									}
+								}
+
+								for branch in config['branches']:
+									result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+								pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines
+
+def notify():
+	result = {
+		'kind': 'pipeline',
+		'type': 'docker',
+		'name': 'chat-notifications',
+		'clone': {
+			'disable': True
+		},
+		'steps': [
+			{
+				'name': 'notify-rocketchat',
+				'image': 'plugins/slack:1',
+				'pull': 'always',
+				'settings': {
+					'webhook': {
+						'from_secret': config['rocketchat']['from_secret']
+					},
+					'channel': config['rocketchat']['channel']
+				}
+			}
+		],
+		'depends_on': [],
+		'trigger': {
+			'ref': [
+				'refs/tags/**'
+			]
+		}
+	}
+
+	for branch in config['branches']:
+		result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+	return result
+
+def databaseService(db):
+	dbName = getDbName(db)
+	if (dbName == 'mariadb') or (dbName == 'mysql'):
+		return [{
+			'name': dbName,
+			'image': db,
+			'pull': 'always',
+			'environment': {
+				'MYSQL_USER': getDbUsername(db),
+				'MYSQL_PASSWORD': getDbPassword(db),
+				'MYSQL_DATABASE': getDbDatabase(db),
+				'MYSQL_ROOT_PASSWORD': getDbRootPassword()
+			}
+		}]
+
+	if dbName == 'postgres':
+		return [{
+			'name': dbName,
+			'image': db,
+			'pull': 'always',
+			'environment': {
+				'POSTGRES_USER': getDbUsername(db),
+				'POSTGRES_PASSWORD': getDbPassword(db),
+				'POSTGRES_DB': getDbDatabase(db)
+			}
+		}]
+
+	if dbName == 'oracle':
+		return [{
+			'name': dbName,
+			'image': 'deepdiver/docker-oracle-xe-11g:latest',
+			'pull': 'always',
+			'environment': {
+				'ORACLE_USER': getDbUsername(db),
+				'ORACLE_PASSWORD': getDbPassword(db),
+				'ORACLE_DB': getDbDatabase(db),
+				'ORACLE_DISABLE_ASYNCH_IO': 'true',
+			}
+		}]
+
+	return []
+
+def browserService(browser):
+	if browser == 'chrome':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-chrome-debug:3.141.59-oxygen',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING'
+			}
+		}]
+
+	if browser == 'firefox':
+		return [{
+			'name': 'selenium',
+			'image': 'selenium/standalone-firefox-debug:3.8.1',
+			'pull': 'always',
+			'environment': {
+				'JAVA_OPTS': '-Dselenium.LOGGER.level=WARNING',
+				'SE_OPTS': '-enablePassThrough false'
+			}
+		}]
+
+	return []
+
+def emailService(emailNeeded):
+	if emailNeeded:
+		return [{
+			'name': 'email',
+			'image': 'mailhog/mailhog',
+			'pull': 'always',
+		}]
+
+	return []
+
+def ldapService(ldapNeeded):
+	if ldapNeeded:
+		return [{
+			'name': 'ldap',
+			'image': 'osixia/openldap',
+			'pull': 'always',
+			'environment': {
+				'LDAP_DOMAIN': 'owncloud.com',
+				'LDAP_ORGANISATION': 'owncloud',
+				'LDAP_ADMIN_PASSWORD': 'admin',
+				'LDAP_TLS_VERIFY_CLIENT': 'never',
+				'HOSTNAME': 'ldap',
+			}
+		}]
+
+	return []
+
+def scalityService(scalityS3):
+	if not scalityS3:
+		return []
+
+	return [{
+		'name': 'scality',
+		'image': 'owncloudci/scality-s3server',
+		'pull': 'always',
+		'environment': {
+			'HOST_NAME': 'scality'
+		}
+	}]
+
+
+def cephService(cephS3):
+	if not cephS3:
+		return []
+
+	return [{
+		'name': 'ceph',
+		'image': 'owncloudci/ceph:tag-build-master-jewel-ubuntu-16.04',
+		'pull': 'always',
+		'environment': {
+			'NETWORK_AUTO_DETECT': '4',
+			'RGW_NAME': 'ceph',
+			'CEPH_DEMO_UID': 'owncloud',
+			'CEPH_DEMO_ACCESS_KEY': 'owncloud123456',
+			'CEPH_DEMO_SECRET_KEY': 'secret123456',
+		}
+	}]
+
+
+def owncloudService(version, phpVersion, name = 'server', path = '/var/www/owncloud/server', ssl = True):
+	if ssl:
+		environment = {
+			'APACHE_WEBROOT': path,
+			'APACHE_CONFIG_TEMPLATE': 'ssl',
+			'APACHE_SSL_CERT_CN': 'server',
+			'APACHE_SSL_CERT': '/var/www/owncloud/%s.crt' % name,
+			'APACHE_SSL_KEY': '/var/www/owncloud/%s.key' % name
+		}
+	else:
+		environment = {
+			'APACHE_WEBROOT': path
+		}
+
+	return [{
+		'name': name,
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'environment': environment,
+		'command': [
+			'/usr/local/bin/apachectl',
+			'-e',
+			'debug',
+			'-D',
+			'FOREGROUND'
+		]
+	}]
+
+def getDbName(db):
+	return db.split(':')[0]
+
+def getDbUsername(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'system'
+
+	return 'owncloud'
+
+def getDbPassword(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'oracle'
+
+	return 'owncloud'
+
+def getDbRootPassword():
+	return 'owncloud'
+
+def getDbDatabase(db):
+	name = getDbName(db)
+
+	if name == 'oracle':
+		return 'XE'
+
+	return 'owncloud'
+
+def installCore(version, db, useBundledApp):
+	host = getDbName(db)
+	dbType = host
+
+	username = getDbUsername(db)
+	password = getDbPassword(db)
+	database = getDbDatabase(db)
+
+	if host == 'mariadb':
+		dbType = 'mysql'
+
+	if host == 'postgres':
+		dbType = 'pgsql'
+
+	if host == 'oracle':
+		dbType = 'oci'
+
+	stepDefinition = {
+		'name': 'install-core',
+		'image': 'owncloudci/core',
+		'pull': 'always',
+		'settings': {
+			'version': version,
+			'core_path': '/var/www/owncloud/server',
+			'db_type': dbType,
+			'db_name': database,
+			'db_host': host,
+			'db_username': username,
+			'db_password': password
+		}
+	}
+
+	if not useBundledApp:
+		stepDefinition['settings']['exclude'] = 'apps/%s' % config['app']
+
+	return [stepDefinition]
+
+def installTestrunner(phpVersion, useBundledApp):
+	return [{
+		'name': 'install-testrunner',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'mkdir /tmp/testrunner',
+			'git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner',
+			'rsync -aIX /tmp/testrunner /var/www/owncloud',
+		] + ([
+			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
+		] if not useBundledApp else []) + [
+			'cd /var/www/owncloud/testrunner',
+			'make install-composer-deps vendor-bin-deps'
+		]
+	}]
+
+def installExtraApps(phpVersion, extraApps):
+	commandArray = []
+	for app, command in extraApps.items():
+		commandArray.append('git clone https://github.com/owncloud/%s.git /var/www/owncloud/testrunner/apps/%s' % (app, app))
+		commandArray.append('cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % app)
+		if (command != ''):
+			commandArray.append('cd /var/www/owncloud/server/apps/%s' % app)
+			commandArray.append(command)
+		commandArray.append('cd /var/www/owncloud/server')
+		commandArray.append('php occ a:l')
+		commandArray.append('php occ a:e %s' % app)
+		commandArray.append('php occ a:l')
+
+	if (commandArray == []):
+		return []
+
+	return [{
+		'name': 'install-extra-apps',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': commandArray
+	}]
+
+def installApp(phpVersion):
+	if 'appInstallCommand' not in config:
+		return []
+
+	return [{
+		'name': 'install-app-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'cd /var/www/owncloud/server/apps/%s' % config['app'],
+			config['appInstallCommand']
+		]
+	}]
+
+def setupServerAndApp(phpVersion, logLevel):
+	return [{
+		'name': 'setup-server-%s' % config['app'],
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'cd /var/www/owncloud/server',
+			'php occ a:l',
+			'php occ a:e %s' % config['app'],
+			'php occ a:e testing',
+			'php occ a:l',
+			'php occ config:system:set trusted_domains 1 --value=server',
+			'php occ log:manage --level %s' % logLevel,
+		]
+	}]
+
+def setupCeph(cephS3):
+	if not cephS3:
+		return []
+
+	return [{
+		'name': 'setup-ceph',
+		'image': 'owncloudci/php:7.0',
+		'pull': 'always',
+		'commands': [
+			'wait-for-it -t 60 ceph:80',
+			'cd /var/www/owncloud/server/apps/files_primary_s3',
+			'cp tests/drone/ceph.config.php /var/www/owncloud/server/config',
+			'cd /var/www/owncloud/server',
+			'./apps/files_primary_s3/tests/drone/create-bucket.sh',
+		]
+	}]
+
+def setupScality(scalityS3):
+	if type(scalityS3) == "bool":
+		if scalityS3:
+			# specify an empty dict that will get the defaults
+			scalityS3 = {}
+		else:
+			return []
+
+	specialConfig = '.' + scalityS3['config'] if 'config' in scalityS3 else ''
+	configFile = 'scality%s.config.php' % specialConfig
+	createExtraBuckets = scalityS3['createExtraBuckets'] if 'createExtraBuckets' in scalityS3 else False
+
+	return [{
+		'name': 'setup-scality',
+		'image': 'owncloudci/php:7.0',
+		'pull': 'always',
+		'commands': [
+			'wait-for-it -t 60 scality:8000',
+			'cd /var/www/owncloud/server/apps/files_primary_s3',
+			'cp tests/drone/%s /var/www/owncloud/server/config' % configFile,
+			'cd /var/www/owncloud/server',
+			'php occ s3:create-bucket owncloud --accept-warning'
+		] + ([
+			'for I in $(seq 1 9); do php ./occ s3:create-bucket  owncloud$I --accept-warning; done',
+		] if createExtraBuckets else [])
+	}]
+
+def fixPermissions(phpVersion, federatedServerNeeded):
+	return [{
+		'name': 'fix-permissions',
+		'image': 'owncloudci/php:%s' % phpVersion,
+		'pull': 'always',
+		'commands': [
+			'chown -R www-data /var/www/owncloud/server'
+		] + ([
+			'chown -R www-data /var/www/owncloud/federated'
+		] if federatedServerNeeded else [])
+	}]
+
+def owncloudLog(server):
+	return [{
+		'name': 'owncloud-log-%s' % server,
+		'image': 'owncloud/ubuntu:18.04',
+		'pull': 'always',
+		'detach': True,
+		'commands': [
+			'tail -f /var/www/owncloud/%s/data/owncloud.log' % server
+		]
+	}]
+
+def dependsOn(earlierStages, nextStages):
+	for earlierStage in earlierStages:
+		for nextStage in nextStages:
+			nextStage['depends_on'].append(earlierStage['name'])

--- a/.drone.starlark
+++ b/.drone.starlark
@@ -38,6 +38,24 @@ config = {
 		},
 	},
 
+	'ldapIntegration': {
+		'integration-tests' : {
+			'tests': [
+				'IntegrationBackupServer',
+				'IntegrationConnect',
+				'IntegrationTestAccessGroupsMatchFilter',
+				'IntegrationTestBackupServer',
+				'IntegrationTestBatchApplyUserAttributes',
+				'IntegrationTestConnect',
+				'IntegrationTestCountUsersByLoginName',
+				'IntegrationTestFetchUsersByLoginName',
+				'IntegrationTestPaging',
+				'User/IntegrationTestUserAvatar',
+				'User/IntegrationTestUserDisplayName',
+			],
+		},
+	},
+
 	'acceptance': {
 		'api-with-core-master-mysql': {
 			'suites': [
@@ -484,11 +502,12 @@ def stagePipelines():
 	jsPipelines = javascript()
 	phpunitPipelines = phptests('phpunit')
 	phpintegrationPipelines = phptests('phpintegration')
+	ldapIntegrationPipelines = ldapIntegration()
 	acceptancePipelines = acceptance()
-	if (buildPipelines == False) or (jsPipelines == False) or (phpunitPipelines == False) or (phpintegrationPipelines == False) or (acceptancePipelines == False):
+	if (buildPipelines == False) or (jsPipelines == False) or (phpunitPipelines == False) or (phpintegrationPipelines == False) or (ldapIntegrationPipelines == False) or (acceptancePipelines == False):
 		return False
 
-	return buildPipelines + jsPipelines + phpunitPipelines + phpintegrationPipelines + acceptancePipelines
+	return buildPipelines + jsPipelines + phpunitPipelines + phpintegrationPipelines + ldapIntegrationPipelines + acceptancePipelines
 
 def afterPipelines():
 	return [
@@ -1697,3 +1716,103 @@ def dependsOn(earlierStages, nextStages):
 	for earlierStage in earlierStages:
 		for nextStage in nextStages:
 			nextStage['depends_on'].append(earlierStage['name'])
+
+# This is custom starlark code added just for user_ldap
+# It is not committed to the starlark "standard" code in other apps because
+# it is just an unusual way that integration tests have been structured here
+def ldapIntegration():
+	pipelines = []
+
+	if 'ldapIntegration' not in config:
+		return pipelines
+
+	if type(config['ldapIntegration']) == "bool":
+		if not config['ldapIntegration']:
+			return pipelines
+
+	errorFound = False
+
+	default = {
+		'servers': ['daily-master-qa'],
+		'phpVersions': ['7.1'],
+		'databases': ['mysql:5.7'],
+		'ldapNeeded': True,
+		'logLevel': '2',
+	}
+
+	if 'defaults' in config:
+		if 'ldapIntegration' in config['defaults']:
+			for item in config['defaults']['ldapIntegration']:
+				default[item] = config['defaults']['ldapIntegration'][item]
+
+	for category, matrix in config['ldapIntegration'].items():
+		if type(matrix['tests']) == "list":
+			tests = {}
+			for test in matrix['tests']:
+				tests[test] = test
+		else:
+			tests = matrix['tests']
+
+		for test, alternateTestName in tests.items():
+			params = {}
+			for item in default:
+				params[item] = matrix[item] if item in matrix else default[item]
+
+			for server in params['servers']:
+				for phpVersion in params['phpVersions']:
+					for db in params['databases']:
+						name = 'unknown'
+
+						name = alternateTestName
+						maxLength = 50
+						nameLength = len(name)
+						if nameLength > maxLength:
+							print("Error: generated stage name of length", nameLength, "is not supported. The maximum length is " + str(maxLength) + ".", name)
+							errorFound = True
+
+						result = {
+							'kind': 'pipeline',
+							'type': 'docker',
+							'name': name,
+							'workspace' : {
+								'base': '/var/www/owncloud',
+								'path': 'server/apps/%s' % config['app']
+							},
+							'steps':
+								installCore(server, db, False) +
+								installApp(phpVersion) +
+								setupServerAndApp(phpVersion, params['logLevel']) +
+							[
+								({
+									'name': 'ldap-integration-tests',
+									'image': 'owncloudci/php:%s' % phpVersion,
+									'pull': 'always',
+									'environment': {
+										'LDAP_HOST': 'ldap'
+									},
+									'commands': [
+										'php -f ./tests/integration/Lib/%s.php' % test,
+									]
+								}),
+							],
+							'services':
+								databaseService(db) +
+								ldapService(params['ldapNeeded']),
+							'depends_on': [],
+							'trigger': {
+								'ref': [
+									'refs/pull/**',
+									'refs/tags/**'
+								]
+							}
+						}
+
+						for branch in config['branches']:
+							result['trigger']['ref'].append('refs/heads/%s' % branch)
+
+						pipelines.append(result)
+
+	if errorFound:
+		return False
+
+	return pipelines

--- a/.drone.yml
+++ b/.drone.yml
@@ -1243,6 +1243,886 @@ depends_on:
 ---
 kind: pipeline
 type: docker
+name: IntegrationBackupServer
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationBackupServer.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationConnect
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationConnect.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestAccessGroupsMatchFilter
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestAccessGroupsMatchFilter.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestBackupServer
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestBackupServer.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestBatchApplyUserAttributes
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestBatchApplyUserAttributes.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestConnect
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestConnect.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestCountUsersByLoginName
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestCountUsersByLoginName.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestFetchUsersByLoginName
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestFetchUsersByLoginName.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: IntegrationTestPaging
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/IntegrationTestPaging.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: User/IntegrationTestUserAvatar
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/User/IntegrationTestUserAvatar.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: User/IntegrationTestUserDisplayName
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: ldap-integration-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - php -f ./tests/integration/Lib/User/IntegrationTestUserDisplayName.php
+  environment:
+    LDAP_HOST: ldap
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
 name: apiProvisioningLDAP-master-mysql5.7-php7.0
 
 platform:
@@ -15185,6 +16065,17 @@ depends_on:
 - phpunit-php7.3-mysql5.7
 - phpunit-php7.3-postgres9.4
 - phpunit-php7.3-oracle
+- IntegrationBackupServer
+- IntegrationConnect
+- IntegrationTestAccessGroupsMatchFilter
+- IntegrationTestBackupServer
+- IntegrationTestBatchApplyUserAttributes
+- IntegrationTestConnect
+- IntegrationTestCountUsersByLoginName
+- IntegrationTestFetchUsersByLoginName
+- IntegrationTestPaging
+- User/IntegrationTestUserAvatar
+- User/IntegrationTestUserDisplayName
 - apiProvisioningLDAP-master-mysql5.7-php7.0
 - apiProvisioningLDAP-master-mysql5.7-php7.1
 - apiProvisioningLDAP-master-mysql5.7-php7.2

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,1515 +1,15292 @@
+---
+kind: pipeline
+type: docker
+name: coding-standard-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
 workspace:
   base: /var/www/owncloud
   path: server/apps/user_ldap
 
-branches: [ master, release*, next* ]
+steps:
+- name: coding-standard
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-style
 
-pipeline:
-  install-core:
-    image: owncloudci/core
-    pull: true
-    version: ${OC_VERSION}
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+---
+kind: pipeline
+type: docker
+name: phan-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
     core_path: /var/www/owncloud/server
-    db_type: ${DB_TYPE}
-    db_name: ${DB_NAME}
-    db_host: ${DB_TYPE}
-    db_username: autotest
+    db_host: sqlite
+    db_name: owncloud
     db_password: owncloud
-    when:
-      matrix:
-        NEED_CORE: true
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
 
-  install-fed-server:
-    image: owncloudci/core
-    pull: true
-    version: ${FEDERATION_OC_VERSION}
-    core_path: /var/www/owncloud/fed-server
-    when:
-      matrix:
-        USE_FEDERATED_SERVER: true
+- name: phan
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-phan
 
-  install-testrunner:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - git clone -b master --depth=1 https://github.com/owncloud/core.git /var/www/owncloud/testrunner
-      - cp -r /var/www/owncloud/server/apps/user_ldap /var/www/owncloud/testrunner/apps/
-      - cd /var/www/owncloud/testrunner
-      - make install-composer-deps
-      - make vendor-bin-deps
-    when:
-      matrix:
-        USE_RELEASE_TARBALL: true
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  configure-federation-server:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/fed-server
-      - php occ a:l
-      - php occ a:e testing
-      - php occ a:l
-      - php occ config:system:set trusted_domains 1 --value=server
-      - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 2
-      - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
-      - php occ config:list
-    when:
-      matrix:
-        USE_FEDERATED_SERVER: true
+---
+kind: pipeline
+type: docker
+name: phan-php7.1
 
-  ldap-config-of-federation-server-for-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/fed-server/
-      - php occ market:install user_ldap
-      - bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh
-      - php occ ldap:show-config
-      - php occ ldap:test-config "LDAPTestId"
-      - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
-      - php occ user:list
-    when:
-      matrix:
-        USE_FEDERATED_SERVER: true
+platform:
+  os: linux
+  arch: amd64
 
-  owncloud-log:
-    image: owncloud/ubuntu:16.04
-    detach: true
-    pull: true
-    commands:
-      - tail -f /var/www/owncloud/server/data/owncloud.log
-    when:
-      matrix:
-        NEED_SERVER: true
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
 
-  owncloud-coding-standard:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - make test-php-style
-    when:
-      matrix:
-        TEST_SUITE: owncloud-coding-standard
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
 
-  install-app:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/server/apps/user_ldap
-      - make
-      - cd /var/www/owncloud/server/
-      - php occ a:l
-      - php occ a:e user_ldap
-      - php occ a:e testing
-      - php occ a:l
-      - php occ config:system:set trusted_domains 1 --value=server
-      - php occ config:system:set trusted_domains 2 --value=federated
-      - php occ log:manage --level 2
-      - php occ config:system:set --value true --type boolean integrity.check.disabled
-    when:
-      matrix:
-        NEED_INSTALL_APP: true
+- name: phan
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-phan
 
-  ldap-config-for-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/server/
-      - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
-    when:
-      matrix:
-        NEED_SERVER: true
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  ldaps-config-for-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/server/
-      - php occ ldap:set-config LDAPTestId ldapPort "636"
-      - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
-    when:
-      matrix:
-        USE_LDAPS: true
+---
+kind: pipeline
+type: docker
+name: phan-php7.2
 
-  ldap-check-config:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - cd /var/www/owncloud/server/
-      - php occ ldap:show-config
-      - php occ ldap:test-config "LDAPTestId"
-      - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
-      - php occ user:list
-    when:
-      matrix:
-        NEED_SERVER: true
+platform:
+  os: linux
+  arch: amd64
 
-  fix-permissions:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - chown www-data /var/www/owncloud -R
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ];
-        then
-        chmod 777 /var/www/owncloud/testrunner/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/testrunner/tests/acceptance/run.sh;
-        else
-        chmod 777 /var/www/owncloud/server/tests/acceptance/filesForUpload -R;
-        chmod +x /var/www/owncloud/server/tests/acceptance/run.sh;
-        fi
-    when:
-      matrix:
-        NEED_SERVER: true
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
 
-  api-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-api
-    when:
-      matrix:
-        TEST_SUITE: api-acceptance
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
 
-  cli-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-cli
-    when:
-      matrix:
-        TEST_SUITE: cli-acceptance
+- name: phan
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-phan
 
-  webui-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - BROWSER=chrome #chrome or firefox
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://server
-      - PLATFORM=Linux
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-webui
-    when:
-      matrix:
-        TEST_SUITE: web-acceptance
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  core-api-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-core-api
-    when:
-      matrix:
-        TEST_SUITE: core-api-acceptance
+---
+kind: pipeline
+type: docker
+name: phan-php7.3
 
-  core-cli-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - TEST_SERVER_URL=http://server
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-core-cli
-    when:
-      matrix:
-        TEST_SUITE: core-cli-acceptance
+platform:
+  os: linux
+  arch: amd64
 
-  core-webui-acceptance-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - BROWSER=chrome #chrome or firefox
-      - SELENIUM_HOST=selenium
-      - SELENIUM_PORT=4444
-      - TEST_SERVER_URL=http://server
-      - PLATFORM=Linux
-      - TEST_EXTERNAL_USER_BACKENDS=true
-      - BEHAT_SUITE=${BEHAT_SUITE}
-    commands:
-      - touch /var/www/owncloud/saved-settings.sh
-      - . /var/www/owncloud/saved-settings.sh
-      - if [ "${USE_RELEASE_TARBALL}" = "true" ]; then cd /var/www/owncloud/testrunner/apps/user_ldap; fi
-      - make test-acceptance-core-webui
-    when:
-      matrix:
-        TEST_SUITE: core-web-acceptance
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
 
-  run-integration-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - LDAP_HOST=ldap
-    commands:
-      - php -f ./tests/integration/Lib/${INTEGRATION_TEST_SCRIPT}
-    when:
-      matrix:
-        TEST_SUITE: integration
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
 
-  phan:
-   image: owncloudci/php:7.1
-   pull: true
-   commands:
-     - make test-php-phan
-   when:
-     matrix:
-       TEST_SUITE: phan
+- name: phan
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-phan
 
-  phpstan:
-    image: owncloudci/php:7.1
-    pull: true
-    commands:
-      - make test-php-phpstan
-    when:
-      matrix:
-        TEST_SUITE: phpstan
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
 
-  phpunit-tests:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - COVERAGE=${COVERAGE}
-    commands:
-      - if [ -z "${COVERAGE}" ]; then make test-php-unit; fi
-      - if [ "${COVERAGE}" = "true" ]; then make test-php-unit-dbg; fi
-    when:
-      matrix:
-        TEST_SUITE: phpunit
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-sqlite
 
-  codecov:
-    image: plugins/codecov:2
-    secrets: [codecov_token]
-    pull: true
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: sqlite
+    db_name: owncloud
+    db_password: owncloud
+    db_type: sqlite
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
     paths:
-      - tests/output/*.xml
-    when:
-      matrix:
-        COVERAGE: true
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
-  notify:
-    image: plugins/slack:1
-    pull: true
-    secrets: [ slack_webhook ]
-    channel: builds
-    when:
-      status: [ failure, changed ]
-      event: [ push, tag ]
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mariadb10.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mariadb
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
 
 services:
-  ldap:
-    image: osixia/openldap
-    detach: true
-    pull: true
-    environment:
-      - LDAP_DOMAIN=owncloud.com
-      - LDAP_ORGANISATION=ownCloud
-      - LDAP_ADMIN_PASSWORD=admin
-      - HOSTNAME=ldap
-      - LDAP_TLS_VERIFY_CLIENT=never
-
-  server:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - APACHE_WEBROOT=/var/www/owncloud/server/
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D" , "FOREGROUND" ]
-    when:
-      matrix:
-        NEED_SERVER: true
-
-  federated:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    environment:
-      - APACHE_WEBROOT=/var/www/owncloud/fed-server/
-    command: [ "/usr/local/bin/apachectl", "-e", "debug" , "-D" , "FOREGROUND" ]
-    when:
-      matrix:
-        USE_FEDERATED_SERVER: true
-
-  selenium:
-    image: selenium/standalone-chrome-debug:3.141.59-oxygen
-    pull: true
-    when:
-      matrix:
-        NEED_SELENIUM: true
-
-  mysql:
-    image: mysql:5.7
-    environment:
-      - MYSQL_USER=autotest
-      - MYSQL_PASSWORD=owncloud
-      - MYSQL_DATABASE=${DB_NAME}
-      - MYSQL_ROOT_PASSWORD=owncloud
-    when:
-      matrix:
-        DB_TYPE: mysql
-
-  pgsql:
-    image: postgres:9.4
-    environment:
-      - POSTGRES_USER=autotest
-      - POSTGRES_PASSWORD=owncloud
-      - POSTGRES_DB=${DB_NAME}
-    when:
-      matrix:
-        DB_TYPE: pgsql
-
-  oci:
-    image: deepdiver/docker-oracle-xe-11g
-    environment:
-      - ORACLE_USER=system
-      - ORACLE_PASSWORD=oracle
-      - ORACLE_DB=${DB_NAME}
-    when:
-      matrix:
-        DB_TYPE: oci
-
-matrix:
-  include:
-    # owncloud-coding-standard
-    - PHP_VERSION: 7.2
-      TEST_SUITE: owncloud-coding-standard
-
-    - PHP_VERSION: 7.0
-      TEST_SUITE: owncloud-coding-standard
-
-    - TEST_SUITE: phan
-      PHP_VERSION: 7.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      OC_VERSION: daily-master-qa
-      NEED_INSTALL_APP: true
-
-    # unit tests
-    # with php 7.1 and core master
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      COVERAGE: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.1
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    # with php 7.2 and core master
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.2
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    # with php 7.3 and core master
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.3
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    # with php 7.0 and core master
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: phpunit
-      PHP_VERSION: 7.0
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    # acceptance tests - ldap specific
-    # with php 7.1 and core master
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: sqlite
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-
-    # acceptance tests - ldap specific
-    # with php 7.2 and core master
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-
-    # acceptance tests - ldap specific
-    # with php 7.0 and core master
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: pgsql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: oci
-      DB_NAME: XE
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-
-    # acceptance tests - ldap specific
-    # with LDAPS
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-      USE_LDAPS: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-      USE_LDAPS: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-      USE_LDAPS: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-      USE_LDAPS: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-      USE_LDAPS: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-      USE_LDAPS: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-      USE_LDAPS: true
-
-    # acceptance tests - UI tests from core
-    - TEST_SUITE: core-web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      NEED_SELENIUM: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      BEHAT_SUITE: webUICore1
-
-    - TEST_SUITE: core-web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      NEED_SELENIUM: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      BEHAT_SUITE: webUICore2
-
-    - TEST_SUITE: core-web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      NEED_SELENIUM: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      BEHAT_SUITE: webUICore1
-
-    - TEST_SUITE: core-web-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.0
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      NEED_SELENIUM: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      BEHAT_SUITE: webUICore2
-
-    #acceptance tests - CLI tests from core
-    # with php 7.1 and core master
-    - TEST_SUITE: core-cli-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliTrashbin
-
-    # acceptance tests - API tests from core
-    # with php 7.1 and core master
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiAuth
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiAuthOcs
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiCapabilities
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiComments
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiFavorites
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      USE_FEDERATED_SERVER: true
-      FEDERATION_OC_VERSION: daily-master-qa
-      BEHAT_SUITE: apiFederation
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiMain
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiSharees
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiShareManagement
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiShareManagementBasic
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiShareOperations
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiShareReshare
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiShareUpdate
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiSharingNotifications
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiTags
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiTrashbin
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiVersions
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavLocks
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavLocks2
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavMove
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavOperations
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavProperties
-
-    - TEST_SUITE: core-api-acceptance
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiWebdavUpload
-
-    # integration tests
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestAccessGroupsMatchFilter.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationBackupServer.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: User/IntegrationTestUserAvatar.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: User/IntegrationTestUserDisplayName.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestBackupServer.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationConnect.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestBatchApplyUserAttributes.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestConnect.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestCountUsersByLoginName.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestFetchUsersByLoginName.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    - TEST_SUITE: integration
-      OC_VERSION: daily-master-qa
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.1
-      INTEGRATION_TEST_SCRIPT: IntegrationTestPaging.php
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-
-    # Release Tarball
-    # acceptance tests - ldap specific
-    # with php 7.2 and core 10.2.1
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-      USE_RELEASE_TARBALL: true
-
-    # Release Tarball
-    # acceptance tests - ldap specific
-    # with LDAPS
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIUserLDAP
-      NEED_SELENIUM: true
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: web-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: webUIProvisioning
-      NEED_SELENIUM: true
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: cli-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: cliProvisioning
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPConnection
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAPSharing
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiProvisioningLDAP
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
-
-    - TEST_SUITE: api-acceptance
-      OC_VERSION: 10.2.1
-      DB_TYPE: mysql
-      DB_NAME: owncloud
-      PHP_VERSION: 7.2
-      NEED_SERVER: true
-      NEED_CORE: true
-      NEED_INSTALL_APP: true
-      BEHAT_SUITE: apiUserLDAP
-      USE_LDAPS: true
-      USE_RELEASE_TARBALL: true
+- name: mariadb
+  pull: always
+  image: mariadb:10.2
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.5
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.5
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.0-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - make test-php-unit-dbg
+
+- name: codecov-upload
+  pull: always
+  image: plugins/codecov:2
+  settings:
+    paths:
+    - tests/output/clover.xml
+    token:
+      from_secret: codecov_token
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.1-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - make test-php-unit
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.2-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - make test-php-unit
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-mysql5.7
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-postgres9.4
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: phpunit-php7.3-oracle
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: server/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: phpunit-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - make test-php-unit
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-master-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-master-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-master-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-master-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAP-latest-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAP-latest-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnection-latest-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharing-latest-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAPS-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiProvisioningLDAPS-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiProvisioningLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPS-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPS-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAP
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnectionS-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPConnectionS-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPConnection
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharingS-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiUserLDAPSharingS-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-api
+  environment:
+    BEHAT_SUITE: apiUserLDAPSharing
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-master-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-latest-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioning-latest-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioningLDAPS-master-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliProvisioningLDAPS-latest-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-cli
+  environment:
+    BEHAT_SUITE: cliProvisioning
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-mysql5.7-php7.0
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.0
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-mysql5.7-php7.3
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.3
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.3
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-master-chrome-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-master-chrome-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-latest-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-latest-chrome-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAP-latest-chrome-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-latest-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-latest-chrome-postgres9.4-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: postgres
+    db_name: owncloud
+    db_password: owncloud
+    db_type: pgsql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: postgres
+  pull: always
+  image: postgres:9.4
+  environment:
+    POSTGRES_DB: owncloud
+    POSTGRES_PASSWORD: owncloud
+    POSTGRES_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioning-latest-chrome-oracle-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: oracle
+    db_name: XE
+    db_password: oracle
+    db_type: oci
+    db_username: system
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: oracle
+  pull: always
+  image: deepdiver/docker-oracle-xe-11g:latest
+  environment:
+    ORACLE_DB: XE
+    ORACLE_DISABLE_ASYNCH_IO: true
+    ORACLE_PASSWORD: oracle
+    ORACLE_USER: system
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAPS-master-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIUserLDAPS-latest-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIUserLDAP
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioningS-master-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUIProvisioningS-latest-chrome-mysql5.7-php7.2
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: latest
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:set-config LDAPTestId ldapPort "636"
+  - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.2
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-webui
+  environment:
+    BEHAT_SUITE: webUIProvisioning
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.2
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiAuth-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiAuth
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiAuthOcs-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiAuthOcs
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiCapabilities-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiCapabilities
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiComments-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiComments
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiFavorites-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiFavorites
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiMain-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiMain
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiSharees-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiSharees
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiShareManagement-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiShareManagement
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiShareManagementBasic-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiShareManagementBasic
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiShareOperations-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiShareOperations
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiShareReshare-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiShareReshare
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiShareUpdate-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiShareUpdate
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiSharingNotifications-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiSharingNotifications
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiTags-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiTags
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiTrashbin-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiTrashbin
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiVersions-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiVersions
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavLocks-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavLocks
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavLocks2-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavLocks2
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavMove-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavMove
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavOperations-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavOperations
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavProperties-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavProperties
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiWebdavUpload-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiWebdavUpload
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: apiFederation-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: daily-master-qa
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: configure-app-on-federated-server
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/federated
+  - php occ market:install user_ldap
+  - bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-api
+  environment:
+    BEHAT_SUITE: apiFederation
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: cliTrashbin-master-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-cli
+  environment:
+    BEHAT_SUITE: cliTrashbin
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUICore1-master-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: daily-master-qa
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: configure-app-on-federated-server
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/federated
+  - php occ market:install user_ldap
+  - bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BEHAT_SUITE: webUICore1
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: webUICore2-master-chrome-mysql5.7-php7.1
+
+platform:
+  os: linux
+  arch: amd64
+
+workspace:
+  base: /var/www/owncloud
+  path: testrunner/apps/user_ldap
+
+steps:
+- name: install-core
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/server
+    db_host: mysql
+    db_name: owncloud
+    db_password: owncloud
+    db_type: mysql
+    db_username: owncloud
+    exclude: apps/user_ldap
+    version: daily-master-qa
+
+- name: install-testrunner
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - mkdir /tmp/testrunner
+  - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
+  - rsync -aIX /tmp/testrunner /var/www/owncloud
+  - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
+  - cd /var/www/owncloud/testrunner
+  - make install-composer-deps vendor-bin-deps
+
+- name: install-federation
+  pull: always
+  image: owncloudci/core
+  settings:
+    core_path: /var/www/owncloud/federated
+    version: daily-master-qa
+
+- name: configure-federation
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - echo "export TEST_SERVER_FED_URL=http://federated" > /var/www/owncloud/saved-settings.sh
+  - cd /var/www/owncloud/federated
+  - php occ a:l
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=federated
+  - php occ log:manage --level 2
+  - php occ config:list
+
+- name: owncloud-log-federated
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/federated/data/owncloud.log
+
+- name: setup-server-user_ldap
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - cd /var/www/owncloud/server
+  - php occ a:l
+  - php occ a:e user_ldap
+  - php occ a:e testing
+  - php occ a:l
+  - php occ config:system:set trusted_domains 1 --value=server
+  - php occ log:manage --level 2
+
+- name: owncloud-log-server
+  pull: always
+  image: owncloud/ubuntu:18.04
+  detach: true
+  commands:
+  - tail -f /var/www/owncloud/server/data/owncloud.log
+
+- name: configure-app
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/server
+  - bash ./apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: configure-app-on-federated-server
+  pull: always
+  image: owncloudci/php:7.0
+  commands:
+  - cd /var/www/owncloud/federated
+  - php occ market:install user_ldap
+  - bash /var/www/owncloud/server/apps/user_ldap/tests/acceptance/setConfig.sh
+  - php occ ldap:show-config
+  - php occ ldap:test-config "LDAPTestId"
+  - php occ user:sync "OCA\User_LDAP\User_Proxy" -m remove
+  - php occ user:list
+
+- name: fix-permissions
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - chown -R www-data /var/www/owncloud/server
+  - chown -R www-data /var/www/owncloud/federated
+
+- name: acceptance-tests
+  pull: always
+  image: owncloudci/php:7.1
+  commands:
+  - touch /var/www/owncloud/saved-settings.sh
+  - . /var/www/owncloud/saved-settings.sh
+  - make test-acceptance-core-webui
+  environment:
+    BEHAT_SUITE: webUICore2
+    BROWSER: chrome
+    PLATFORM: Linux
+    SELENIUM_HOST: selenium
+    SELENIUM_PORT: 4444
+    TEST_EXTERNAL_USER_BACKENDS: true
+    TEST_SERVER_URL: http://server
+
+services:
+- name: mysql
+  pull: always
+  image: mysql:5.7
+  environment:
+    MYSQL_DATABASE: owncloud
+    MYSQL_PASSWORD: owncloud
+    MYSQL_ROOT_PASSWORD: owncloud
+    MYSQL_USER: owncloud
+
+- name: selenium
+  pull: always
+  image: selenium/standalone-chrome-debug:3.141.59-oxygen
+  environment:
+    JAVA_OPTS: -Dselenium.LOGGER.level=WARNING
+
+- name: ldap
+  pull: always
+  image: osixia/openldap
+  environment:
+    HOSTNAME: ldap
+    LDAP_ADMIN_PASSWORD: admin
+    LDAP_DOMAIN: owncloud.com
+    LDAP_ORGANISATION: owncloud
+    LDAP_TLS_VERIFY_CLIENT: never
+
+- name: server
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/server
+
+- name: federated
+  pull: always
+  image: owncloudci/php:7.1
+  command:
+  - /usr/local/bin/apachectl
+  - -e
+  - debug
+  - -D
+  - FOREGROUND
+  environment:
+    APACHE_WEBROOT: /var/www/owncloud/federated
+
+trigger:
+  ref:
+  - refs/pull/**
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- coding-standard-php7.0
+- phan-php7.0
+- phan-php7.1
+- phan-php7.2
+- phan-php7.3
+
+---
+kind: pipeline
+type: docker
+name: chat-notifications
+
+platform:
+  os: linux
+  arch: amd64
+
+clone:
+  disable: true
+
+steps:
+- name: notify-rocketchat
+  pull: always
+  image: plugins/slack:1
+  settings:
+    channel: builds
+    webhook:
+      from_secret: private_rocketchat
+
+trigger:
+  ref:
+  - refs/tags/**
+  - refs/heads/master
+
+depends_on:
+- phpunit-php7.0-sqlite
+- phpunit-php7.0-mariadb10.2
+- phpunit-php7.0-mysql5.5
+- phpunit-php7.0-mysql5.7
+- phpunit-php7.0-postgres9.4
+- phpunit-php7.0-oracle
+- phpunit-php7.1-mysql5.7
+- phpunit-php7.1-postgres9.4
+- phpunit-php7.1-oracle
+- phpunit-php7.2-mysql5.7
+- phpunit-php7.2-postgres9.4
+- phpunit-php7.2-oracle
+- phpunit-php7.3-mysql5.7
+- phpunit-php7.3-postgres9.4
+- phpunit-php7.3-oracle
+- apiProvisioningLDAP-master-mysql5.7-php7.0
+- apiProvisioningLDAP-master-mysql5.7-php7.1
+- apiProvisioningLDAP-master-mysql5.7-php7.2
+- apiProvisioningLDAP-master-mysql5.7-php7.3
+- apiUserLDAP-master-mysql5.7-php7.0
+- apiUserLDAP-master-mysql5.7-php7.1
+- apiUserLDAP-master-mysql5.7-php7.2
+- apiUserLDAP-master-mysql5.7-php7.3
+- apiUserLDAPConnection-master-mysql5.7-php7.0
+- apiUserLDAPConnection-master-mysql5.7-php7.1
+- apiUserLDAPConnection-master-mysql5.7-php7.2
+- apiUserLDAPConnection-master-mysql5.7-php7.3
+- apiUserLDAPSharing-master-mysql5.7-php7.0
+- apiUserLDAPSharing-master-mysql5.7-php7.1
+- apiUserLDAPSharing-master-mysql5.7-php7.2
+- apiUserLDAPSharing-master-mysql5.7-php7.3
+- apiProvisioningLDAP-master-postgres9.4-php7.2
+- apiProvisioningLDAP-master-oracle-php7.2
+- apiUserLDAP-master-postgres9.4-php7.2
+- apiUserLDAP-master-oracle-php7.2
+- apiUserLDAPConnection-master-postgres9.4-php7.2
+- apiUserLDAPConnection-master-oracle-php7.2
+- apiUserLDAPSharing-master-postgres9.4-php7.2
+- apiUserLDAPSharing-master-oracle-php7.2
+- apiProvisioningLDAP-latest-mysql5.7-php7.2
+- apiProvisioningLDAP-latest-postgres9.4-php7.2
+- apiProvisioningLDAP-latest-oracle-php7.2
+- apiUserLDAP-latest-mysql5.7-php7.2
+- apiUserLDAP-latest-postgres9.4-php7.2
+- apiUserLDAP-latest-oracle-php7.2
+- apiUserLDAPConnection-latest-mysql5.7-php7.2
+- apiUserLDAPConnection-latest-postgres9.4-php7.2
+- apiUserLDAPConnection-latest-oracle-php7.2
+- apiUserLDAPSharing-latest-mysql5.7-php7.2
+- apiUserLDAPSharing-latest-postgres9.4-php7.2
+- apiUserLDAPSharing-latest-oracle-php7.2
+- apiProvisioningLDAPS-master-mysql5.7-php7.2
+- apiProvisioningLDAPS-latest-mysql5.7-php7.2
+- apiUserLDAPS-master-mysql5.7-php7.2
+- apiUserLDAPS-latest-mysql5.7-php7.2
+- apiUserLDAPConnectionS-master-mysql5.7-php7.2
+- apiUserLDAPConnectionS-latest-mysql5.7-php7.2
+- apiUserLDAPSharingS-master-mysql5.7-php7.2
+- apiUserLDAPSharingS-latest-mysql5.7-php7.2
+- cliProvisioning-master-mysql5.7-php7.0
+- cliProvisioning-master-mysql5.7-php7.1
+- cliProvisioning-master-mysql5.7-php7.2
+- cliProvisioning-master-mysql5.7-php7.3
+- cliProvisioning-master-postgres9.4-php7.2
+- cliProvisioning-master-oracle-php7.2
+- cliProvisioning-latest-mysql5.7-php7.2
+- cliProvisioning-latest-postgres9.4-php7.2
+- cliProvisioning-latest-oracle-php7.2
+- cliProvisioningLDAPS-master-mysql5.7-php7.2
+- cliProvisioningLDAPS-latest-mysql5.7-php7.2
+- webUIUserLDAP-master-chrome-mysql5.7-php7.0
+- webUIUserLDAP-master-chrome-mysql5.7-php7.1
+- webUIUserLDAP-master-chrome-mysql5.7-php7.2
+- webUIUserLDAP-master-chrome-mysql5.7-php7.3
+- webUIProvisioning-master-chrome-mysql5.7-php7.0
+- webUIProvisioning-master-chrome-mysql5.7-php7.1
+- webUIProvisioning-master-chrome-mysql5.7-php7.2
+- webUIProvisioning-master-chrome-mysql5.7-php7.3
+- webUIUserLDAP-master-chrome-postgres9.4-php7.2
+- webUIUserLDAP-master-chrome-oracle-php7.2
+- webUIProvisioning-master-chrome-postgres9.4-php7.2
+- webUIProvisioning-master-chrome-oracle-php7.2
+- webUIUserLDAP-latest-chrome-mysql5.7-php7.2
+- webUIUserLDAP-latest-chrome-postgres9.4-php7.2
+- webUIUserLDAP-latest-chrome-oracle-php7.2
+- webUIProvisioning-latest-chrome-mysql5.7-php7.2
+- webUIProvisioning-latest-chrome-postgres9.4-php7.2
+- webUIProvisioning-latest-chrome-oracle-php7.2
+- webUIUserLDAPS-master-chrome-mysql5.7-php7.2
+- webUIUserLDAPS-latest-chrome-mysql5.7-php7.2
+- webUIProvisioningS-master-chrome-mysql5.7-php7.2
+- webUIProvisioningS-latest-chrome-mysql5.7-php7.2
+- apiAuth-master-mysql5.7-php7.1
+- apiAuthOcs-master-mysql5.7-php7.1
+- apiCapabilities-master-mysql5.7-php7.1
+- apiComments-master-mysql5.7-php7.1
+- apiFavorites-master-mysql5.7-php7.1
+- apiMain-master-mysql5.7-php7.1
+- apiSharees-master-mysql5.7-php7.1
+- apiShareManagement-master-mysql5.7-php7.1
+- apiShareManagementBasic-master-mysql5.7-php7.1
+- apiShareOperations-master-mysql5.7-php7.1
+- apiShareReshare-master-mysql5.7-php7.1
+- apiShareUpdate-master-mysql5.7-php7.1
+- apiSharingNotifications-master-mysql5.7-php7.1
+- apiTags-master-mysql5.7-php7.1
+- apiTrashbin-master-mysql5.7-php7.1
+- apiVersions-master-mysql5.7-php7.1
+- apiWebdavLocks-master-mysql5.7-php7.1
+- apiWebdavLocks2-master-mysql5.7-php7.1
+- apiWebdavMove-master-mysql5.7-php7.1
+- apiWebdavOperations-master-mysql5.7-php7.1
+- apiWebdavProperties-master-mysql5.7-php7.1
+- apiWebdavUpload-master-mysql5.7-php7.1
+- apiFederation-master-mysql5.7-php7.1
+- cliTrashbin-master-mysql5.7-php7.1
+- webUICore1-master-chrome-mysql5.7-php7.1
+- webUICore2-master-chrome-mysql5.7-php7.1
+
+...

--- a/.drone.yml
+++ b/.drone.yml
@@ -486,6 +486,31 @@ matrix:
       NEED_CORE: true
       NEED_INSTALL_APP: true
 
+    # with php 7.3 and core master
+    - TEST_SUITE: phpunit
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      DB_TYPE: mysql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+
+    - TEST_SUITE: phpunit
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      DB_TYPE: pgsql
+      DB_NAME: owncloud
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+
+    - TEST_SUITE: phpunit
+      PHP_VERSION: 7.3
+      OC_VERSION: daily-master-qa
+      DB_TYPE: oci
+      DB_NAME: XE
+      NEED_CORE: true
+      NEED_INSTALL_APP: true
+
     # with php 7.0 and core master
     - TEST_SUITE: phpunit
       PHP_VERSION: 7.0

--- a/.drone.yml
+++ b/.drone.yml
@@ -111,19 +111,6 @@ pipeline:
       matrix:
         NEED_INSTALL_APP: true
 
-  install-user-management-app:
-    image: owncloudci/php:${PHP_VERSION}
-    pull: true
-    commands:
-      - git clone https://github.com/owncloud/user_management.git /var/www/owncloud/server/apps/user_management
-      - cd /var/www/owncloud/server
-      - php occ a:l
-      - php occ a:e user_management
-      - php occ a:l
-    when:
-      matrix:
-        NEED_USER_MANAGEMENT_APP: true
-
   ldap-config-for-acceptance-tests:
     image: owncloudci/php:${PHP_VERSION}
     pull: true
@@ -589,7 +576,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
       OC_VERSION: daily-master-qa
@@ -601,7 +587,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
       OC_VERSION: daily-master-qa
@@ -613,7 +598,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: cli-acceptance
       OC_VERSION: daily-master-qa
@@ -699,7 +683,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: web-acceptance
       OC_VERSION: daily-master-qa
@@ -711,7 +694,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
 
     - TEST_SUITE: cli-acceptance
       OC_VERSION: daily-master-qa
@@ -1386,7 +1368,6 @@ matrix:
       NEED_INSTALL_APP: true
       BEHAT_SUITE: webUIProvisioning
       NEED_SELENIUM: true
-      NEED_USER_MANAGEMENT_APP: true
       USE_RELEASE_TARBALL: true
 
     - TEST_SUITE: cli-acceptance

--- a/.drone.yml
+++ b/.drone.yml
@@ -16048,6 +16048,9 @@ trigger:
   ref:
   - refs/tags/**
   - refs/heads/master
+  status:
+  - success
+  - failure
 
 depends_on:
 - phpunit-php7.0-sqlite

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,17 +5,6 @@ workspace:
 branches: [ master, release*, next* ]
 
 pipeline:
-  ldap:
-    image: osixia/openldap
-    detach: true
-    pull: true
-    environment:
-      - LDAP_DOMAIN=owncloud.com
-      - LDAP_ORGANISATION=ownCloud
-      - LDAP_ADMIN_PASSWORD=admin
-      - HOSTNAME=ldap
-      - LDAP_TLS_VERIFY_CLIENT=never
-
   install-core:
     image: owncloudci/core
     pull: true
@@ -351,6 +340,17 @@ pipeline:
       event: [ push, tag ]
 
 services:
+  ldap:
+    image: osixia/openldap
+    detach: true
+    pull: true
+    environment:
+      - LDAP_DOMAIN=owncloud.com
+      - LDAP_ORGANISATION=ownCloud
+      - LDAP_ADMIN_PASSWORD=admin
+      - HOSTNAME=ldap
+      - LDAP_TLS_VERIFY_CLIENT=never
+
   server:
     image: owncloudci/php:${PHP_VERSION}
     pull: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -27,162 +27,6 @@ trigger:
 ---
 kind: pipeline
 type: docker
-name: phan-php7.0
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/user_ldap
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/user_ldap
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.0
-  commands:
-  - make test-php-phan
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
-name: phan-php7.1
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/user_ldap
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/user_ldap
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.1
-  commands:
-  - make test-php-phan
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
-name: phan-php7.2
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/user_ldap
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/user_ldap
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.2
-  commands:
-  - make test-php-phan
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
-name: phan-php7.3
-
-platform:
-  os: linux
-  arch: amd64
-
-workspace:
-  base: /var/www/owncloud
-  path: server/apps/user_ldap
-
-steps:
-- name: install-core
-  pull: always
-  image: owncloudci/core
-  settings:
-    core_path: /var/www/owncloud/server
-    db_host: sqlite
-    db_name: owncloud
-    db_password: owncloud
-    db_type: sqlite
-    db_username: owncloud
-    exclude: apps/user_ldap
-    version: daily-master-qa
-
-- name: phan
-  pull: always
-  image: owncloudci/php:7.3
-  commands:
-  - make test-php-phan
-
-trigger:
-  ref:
-  - refs/pull/**
-  - refs/tags/**
-  - refs/heads/master
-
----
-kind: pipeline
-type: docker
 name: phpunit-php7.0-sqlite
 
 platform:
@@ -242,10 +86,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -319,10 +159,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -396,10 +232,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -473,10 +305,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -549,10 +377,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -626,10 +450,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -694,10 +514,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -761,10 +577,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -829,10 +641,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -897,10 +705,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -964,10 +768,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1032,10 +832,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1100,10 +896,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1167,10 +959,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1235,10 +1023,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1315,10 +1099,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1395,10 +1175,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1475,10 +1251,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1555,10 +1327,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1635,10 +1403,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1715,10 +1479,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1795,10 +1555,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1875,10 +1631,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -1955,10 +1707,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2035,10 +1783,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2115,10 +1859,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2246,10 +1986,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2377,10 +2113,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2508,10 +2240,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2639,10 +2367,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2770,10 +2494,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -2901,10 +2621,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3032,10 +2748,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3163,10 +2875,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3294,10 +3002,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3425,10 +3129,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3556,10 +3256,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3687,10 +3383,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3818,10 +3510,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -3949,10 +3637,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4080,10 +3764,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4211,10 +3891,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4341,10 +4017,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4472,10 +4144,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4602,10 +4270,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4733,10 +4397,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4863,10 +4523,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -4994,10 +4650,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5124,10 +4776,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5255,10 +4903,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5386,10 +5030,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5516,10 +5156,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5647,10 +5283,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5778,10 +5410,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -5908,10 +5536,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6039,10 +5663,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6170,10 +5790,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6300,10 +5916,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6431,10 +6043,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6562,10 +6170,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6692,10 +6296,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6823,10 +6423,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -6956,10 +6552,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7089,10 +6681,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7222,10 +6810,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7355,10 +6939,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7488,10 +7068,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7621,10 +7197,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7754,10 +7326,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -7887,10 +7455,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8018,10 +7582,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8149,10 +7709,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8280,10 +7836,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8411,10 +7963,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8541,10 +8089,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8672,10 +8216,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8803,10 +8343,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -8933,10 +8469,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9064,10 +8596,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9197,10 +8725,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9330,10 +8854,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9471,10 +8991,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9612,10 +9128,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9753,10 +9265,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -9894,10 +9402,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10035,10 +9539,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10176,10 +9676,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10317,10 +9813,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10458,10 +9950,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10598,10 +10086,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10739,10 +10223,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -10879,10 +10359,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11020,10 +10496,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11161,10 +10633,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11301,10 +10769,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11442,10 +10906,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11583,10 +11043,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11723,10 +11179,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -11864,10 +11316,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12007,10 +11455,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12150,10 +11594,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12293,10 +11733,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12436,10 +11872,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12567,10 +11999,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12698,10 +12126,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12829,10 +12253,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -12960,10 +12380,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13091,10 +12507,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13222,10 +12634,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13353,10 +12761,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13484,10 +12888,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13615,10 +13015,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13746,10 +13142,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -13877,10 +13269,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14008,10 +13396,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14139,10 +13523,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14270,10 +13650,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14401,10 +13777,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14532,10 +13904,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14663,10 +14031,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14794,10 +14158,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -14925,10 +14285,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15056,10 +14412,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15187,10 +14539,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15318,10 +14666,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15501,10 +14845,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15632,10 +14972,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -15825,10 +15161,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline
@@ -16018,10 +15350,6 @@ trigger:
 
 depends_on:
 - coding-standard-php7.0
-- phan-php7.0
-- phan-php7.1
-- phan-php7.2
-- phan-php7.3
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -154,7 +154,6 @@ pipeline:
       - php occ ldap:set-config LDAPTestId ldapHost "ldaps://ldap"
     when:
       matrix:
-        NEED_SERVER: true
         USE_LDAPS: true
 
   ldap-check-config:

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -17,6 +17,16 @@ default:
         - '%paths.base%/../../../../../tests/acceptance/features/webUIRenameFolders'
         - '%paths.base%/../../../../../tests/acceptance/features/webUIRestrictSharing'
         - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAcceptShares'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAutocompletion'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalGroups'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingNotifications'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingPublic'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITags'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUITrashbin'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIUpload'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLockProtection'
+        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLocks'
       context: &common_ldap_suite_context
         parameters:
           ldapAdminPassword: admin
@@ -46,17 +56,7 @@ default:
 
     webUICore2:
       paths:
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingAutocompletion'
         - '%paths.base%/../../../../../tests/acceptance/features/webUISharingExternal'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalGroups'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingInternalUsers'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingNotifications'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUISharingPublic'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUITags'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUITrashbin'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIUpload'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLockProtection'
-        - '%paths.base%/../../../../../tests/acceptance/features/webUIWebdavLocks'
       context: *common_ldap_suite_context
       contexts: *common_webui_core_contexts
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -144,6 +144,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -155,6 +156,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -166,6 +168,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -177,6 +180,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -188,6 +192,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - TrashbinContext:
         - WebDavPropertiesContext:
@@ -237,6 +242,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - WebDavLockingContext:
         - WebDavPropertiesContext:
@@ -248,6 +254,7 @@ default:
       contexts:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
+        - OccContext:
         - PublicWebDavContext:
         - WebDavLockingContext:
         - WebDavPropertiesContext:
@@ -271,6 +278,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
         - SearchContext:
+        - OccContext:
         - PublicWebDavContext:
 
     apiWebdavProperties:
@@ -291,6 +299,7 @@ default:
         - UserLdapGeneralContext:
         - FeatureContext: *common_feature_context_params
         - LoggingContext:
+        - OccContext:
         - PublicWebDavContext:
 
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -280,6 +280,7 @@ default:
         - SearchContext:
         - OccContext:
         - PublicWebDavContext:
+        - WebDavPropertiesContext:
 
     apiWebdavProperties:
       paths:

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,5 +1,8 @@
 {
     "require": {
         "squizlabs/php_codesniffer": "3.*"
+    },
+    "conflict": {
+        "squizlabs/php_codesniffer": "3.5.1"
     }
 }


### PR DESCRIPTION
Cherry-pick "recent" drone CI changes into the `release-0.14.0` branch so that it can successfully run current CI.

From CI-related PRs:
#448 
#450 
#452 
#454 
#455 
#458 
#459 
#464 
#462 

Then disable running `phan` in CI, because the "hotfix" PR #449 that is in the release branch has temporarily put back code that does not pass `phan`