### PR TITLE
Adjust behat.yml apiVersions due to core 36391

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -234,6 +234,7 @@ default:
         - FeatureContext: *common_feature_context_params
         - ChecksumContext:
         - FilesVersionsContext:
+        - WebDavPropertiesContext:
 
     apiWebdavLocks:
       paths:


### PR DESCRIPTION
https://github.com/owncloud/core/pull/36391 new test scenario in apiVersions needed WebDavPropertiesContext. So we also need it here in `user_ldap` when running apiVersions suite from code.