### PR TITLE
Detect a new DN by UUID attribute

### DIFF
--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -199,7 +199,8 @@ class User_LDAP implements IUserBackend, UserInterface {
 			$this->userManager->getUserEntryByDn($dn);
 			return true;
 		} catch (DoesNotExistOnLDAPException $e) {
-			return false;
+			// Was DN moved? Try to find a new DN by UUID
+			return $this->userManager->resolveMissingDN($dn);
 		}
 	}
 

--- a/tests/unit/User_LDAPTest.php
+++ b/tests/unit/User_LDAPTest.php
@@ -228,6 +228,10 @@ class User_LDAPTest extends \Test\TestCase {
 			->method('getUserEntryByDn')
 			->with($this->equalTo('cn=foo,dc=foobar,dc=bar'))
 			->will($this->throwException($e));
+		$this->manager->expects($this->once())
+			->method('resolveMissingDN')
+			->with($this->equalTo('cn=foo,dc=foobar,dc=bar'))
+			->willReturn(false);
 
 		$result = $this->backend->userExists('563418fc-423b-1033-8d1c-ad5f418ee02e');
 		$this->assertFalse($result);


### PR DESCRIPTION
## Summary
I'm reusing an orphaned method `OCA\User_LDAP\User\Manager::dnExistsOnLDAP` to search the missing DN by UUID mapping
Please note that **UUID Attribute for Users** aka  `ldap_expert_uuid_user_attr`  should have really unique values.

## Steps
0. Prepare the following structure:
```
ou=parent,dc=owncloudqa,dc=com
  ou=unit1,ou=parent,dc=owncloudqa,dc=com
  ou=unit2,ou=parent,dc=owncloudqa,dc=com
```
1. Put users into  `ou=unit1,ou=parent,dc=owncloudqa,dc=com`
2. Setup user_ldap app:
add `ou=parent,dc=owncloudqa,dc=com` as a `ldap_base_users` 
In the expert tab add `UUID Attribute for Users` e.g. to be `uid`
3.  Execute `php occ user:sync -m remove "OCA\User_LDAP\User_Proxy"`
4. Login as any Ldap user, upload a new file and logout
5. **Move** this user from `ou=unit1,ou=parent,dc=owncloudqa,dc=com` to `ou=unit2,ou=parent,dc=owncloudqa,dc=com`
6.  Execute `php occ user:sync -m remove "OCA\User_LDAP\User_Proxy"`
7. Login as this user once again

### Expected
the user has a file uploaded on the step 4

### Actual 
the user has a skeleton only, firstrunwizard popup appears

## Issue
Fixes https://github.com/owncloud/enterprise/issues/3590

## There are some open questions:
- [x] Q. Should it always try to resole a missing DN by UUID or it is not desired in some cases? 
As it is possible to set any attribute  as UUID this attribute could be non-unique sometimes.
A. If duplication is detected we log it and skip this user.

- [x] Q. What should happen if the LDAP connection is lost while searching a new DN by UUID in the middle of user sync process?
A. We stop the sync