### PR TITLE
Add sabre/xml to behat dependencies

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -2249,10 +2249,7 @@ def installTestrunner(phpVersion, useBundledApp):
 			'rsync -aIX /tmp/testrunner /var/www/owncloud',
 		] + ([
 			'cp -r /var/www/owncloud/testrunner/apps/%s /var/www/owncloud/server/apps/' % config['app']
-		] if not useBundledApp else []) + [
-			'cd /var/www/owncloud/testrunner',
-			'make install-composer-deps'
-		]
+		] if not useBundledApp else [])
 	}]
 
 def installExtraApps(phpVersion, extraApps):

--- a/.drone.yml
+++ b/.drone.yml
@@ -1890,8 +1890,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2020,8 +2018,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2150,8 +2146,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2280,8 +2274,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2410,8 +2402,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2540,8 +2530,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2670,8 +2658,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2800,8 +2786,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -2930,8 +2914,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3060,8 +3042,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3190,8 +3170,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3320,8 +3298,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3450,8 +3426,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3579,8 +3553,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3709,8 +3681,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3838,8 +3808,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -3968,8 +3936,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4097,8 +4063,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4227,8 +4191,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4356,8 +4318,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4486,8 +4446,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4616,8 +4574,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4745,8 +4701,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -4875,8 +4829,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5005,8 +4957,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5134,8 +5084,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5264,8 +5212,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5394,8 +5340,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5523,8 +5467,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5653,8 +5595,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5783,8 +5723,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -5912,8 +5850,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6042,8 +5978,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6174,8 +6108,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6306,8 +6238,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6438,8 +6368,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6570,8 +6498,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6702,8 +6628,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6834,8 +6758,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -6966,8 +6888,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7098,8 +7018,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7228,8 +7146,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7358,8 +7274,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7488,8 +7402,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7617,8 +7529,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7747,8 +7657,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -7877,8 +7785,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8006,8 +7912,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8136,8 +8040,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8268,8 +8170,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8400,8 +8300,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8540,8 +8438,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8680,8 +8576,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8820,8 +8714,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -8960,8 +8852,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9100,8 +8990,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9240,8 +9128,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9379,8 +9265,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9519,8 +9403,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9658,8 +9540,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9798,8 +9678,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -9938,8 +9816,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10077,8 +9953,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10217,8 +10091,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10357,8 +10229,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10496,8 +10366,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10636,8 +10504,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10778,8 +10644,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -10920,8 +10784,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11062,8 +10924,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11204,8 +11064,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11334,8 +11192,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11464,8 +11320,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11594,8 +11448,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11724,8 +11576,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11854,8 +11704,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -11984,8 +11832,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12114,8 +11960,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12244,8 +12088,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12374,8 +12216,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12504,8 +12344,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12634,8 +12472,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12764,8 +12600,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -12894,8 +12728,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13024,8 +12856,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13154,8 +12984,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13284,8 +13112,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13414,8 +13240,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13544,8 +13368,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13674,8 +13496,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13804,8 +13624,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -13934,8 +13752,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14064,8 +13880,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14192,8 +14006,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14320,8 +14132,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14448,8 +14258,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14576,8 +14384,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14704,8 +14510,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14832,8 +14636,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -14960,8 +14762,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15088,8 +14888,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15216,8 +15014,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15344,8 +15140,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15472,8 +15266,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15600,8 +15392,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15728,8 +15518,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15856,8 +15644,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -15984,8 +15770,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16112,8 +15896,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16240,8 +16022,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16368,8 +16148,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16496,8 +16274,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16624,8 +16400,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16752,8 +16526,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -16880,8 +16652,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -17062,8 +16832,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -17242,8 +17010,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -17372,8 +17138,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: setup-server-user_ldap
   pull: always
@@ -17500,8 +17264,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -17692,8 +17454,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -17884,8 +17644,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -18074,8 +17832,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -18264,8 +18020,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -18413,8 +18167,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -18562,8 +18314,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -18711,8 +18461,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -18860,8 +18608,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19009,8 +18755,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19158,8 +18902,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19307,8 +19049,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19456,8 +19196,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19605,8 +19343,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19754,8 +19490,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -19903,8 +19637,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20052,8 +19784,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20201,8 +19931,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20350,8 +20078,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20499,8 +20225,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20648,8 +20372,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20797,8 +20519,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -20946,8 +20666,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -21095,8 +20813,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -21244,8 +20960,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -21393,8 +21107,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -21542,8 +21254,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -21743,8 +21453,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -21892,8 +21600,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -22103,8 +21809,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -22314,8 +22018,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -22463,8 +22165,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -22612,8 +22312,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -22761,8 +22459,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -22910,8 +22606,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23059,8 +22753,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23208,8 +22900,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23357,8 +23047,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23506,8 +23194,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23655,8 +23341,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23804,8 +23488,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -23953,8 +23635,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24102,8 +23782,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24251,8 +23929,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24400,8 +24076,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24549,8 +24223,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24698,8 +24370,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24847,8 +24517,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -24996,8 +24664,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -25145,8 +24811,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -25294,8 +24958,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -25443,8 +25105,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -25592,8 +25252,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -25793,8 +25451,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-extra-apps
   pull: always
@@ -25942,8 +25598,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always
@@ -26153,8 +25807,6 @@ steps:
   - git clone -b master --depth=1 https://github.com/owncloud/core.git /tmp/testrunner
   - rsync -aIX /tmp/testrunner /var/www/owncloud
   - cp -r /var/www/owncloud/testrunner/apps/user_ldap /var/www/owncloud/server/apps/
-  - cd /var/www/owncloud/testrunner
-  - make install-composer-deps
 
 - name: install-federation
   pull: always

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -13,6 +13,7 @@
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.0",
         "symfony/translation": "^3.4",
+        "sabre/xml": "^2.1",
         "guzzlehttp/guzzle": "^5.3",
         "phpunit/phpunit": "^7.5"
     }


### PR DESCRIPTION
It is needed by core `HttpRequestHelper.php` `parseResponseAsXml`

And there is no longer any need to `make install-composer-deps` in the testrunner core folder, because those dependencies are not used by behat any more.