### PR TITLE
Migrate ldap connection and configurations from user_ldap tests to core tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
         }
     },
     "require-dev": {
-        "bamarni/composer-bin-plugin": "^1.2",
-        "zendframework/zend-ldap": "^2.8"
+        "bamarni/composer-bin-plugin": "^1.2"
     },
     "require": {
         "php": ">=7.0.8",

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -32,7 +32,8 @@ default:
           ldapAdminPassword: admin
           ldapUsersOU: TestUsers
           ldapGroupsOU: TestGroups
-          ldapInitialUserFilePath: /../../config/ldap-users.ldif
+          ldapInitialUserFilePath: /../../../../tests/acceptance/config/ldap-users.ldif
+
       contexts: &common_webui_core_contexts
         - UserLdapGeneralContext:
         - FeatureContext: &common_feature_context_params
@@ -43,6 +44,7 @@ default:
             regularUserPassword: 123456
         - EmailContext:
         - FederationContext:
+        - OccContext:
         - WebUIAdminSharingSettingsContext:
         - WebUIFilesContext:
         - WebUIGeneralContext:

--- a/tests/acceptance/features/apiProvisioningLDAP/groups.feature
+++ b/tests/acceptance/features/apiProvisioningLDAP/groups.feature
@@ -63,6 +63,7 @@ Feature: manage groups
 
   Scenario Outline: Administrator tries to delete a ldap group
     Given using OCS API version "<ocs-api-version>"
+    And group "grp1" has been created
     When the LDAP users are resynced
     And the administrator deletes group "grp1" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
@@ -76,6 +77,7 @@ Feature: manage groups
   @issue-core-25224
   Scenario Outline: Add database user to ldap group
     Given using OCS API version "<ocs-api-version>"
+    And group "grp1" has been created
     And user "db-user" has been created with default attributes in the database user backend
     When the administrator adds user "db-user" to group "grp1" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
@@ -91,6 +93,7 @@ Feature: manage groups
   Scenario Outline: Add ldap user to database group
     Given using OCS API version "<ocs-api-version>"
     And group "db-group" has been created in the database user backend
+    And user "user1" has been created with default attributes and without skeleton files
     When the administrator adds user "user1" to group "db-group" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "<http-status-code>"
@@ -103,6 +106,8 @@ Feature: manage groups
   @issue-core-25224
   Scenario Outline: Add ldap user to ldap group
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
+    And group "grp2" has been created
     When the administrator adds user "user1" to group "grp2" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "<http-status-code>"
@@ -116,6 +121,10 @@ Feature: manage groups
 
   Scenario: Add ldap group with same name as existing database group
     Given group "db-group" has been created in the database user backend
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
     And user "user1" has been added to database backend group "db-group"
     When the administrator imports this ldif data:
       """
@@ -133,12 +142,21 @@ Feature: manage groups
     But user "user1" should belong to group "db-group"
 
   Scenario: creating a group in an OU that is different to the other groups
+    Given user "user3" has been created with default attributes and without skeleton files
     When the administrator creates group "new-group-in-other-ou" in ldap OU "TestUsers"
     And the administrator adds user "user3" to group "new-group-in-other-ou" in ldap OU "TestUsers"
     And the administrator invokes occ command "group:list"
     Then user "user3" should belong to group "new-group-in-other-ou"
 
   Scenario: creating a group with a name that already exists in LDAP but in a other OU
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user2    |
+      | user3    |
+    And these groups have been created:
+      | groupname     |
+      | grp1          |
+    And user "user2" has been added to group "grp1"
     When the administrator creates group "grp1" in ldap OU "TestUsers"
     And the administrator adds user "user3" to group "grp1" in ldap OU "TestUsers"
     And the administrator invokes occ command "group:list"
@@ -147,6 +165,10 @@ Feature: manage groups
     And group "grp1_2" should not exist
 
   Scenario: creating two groups with the same name in different LDAP OUs at the same time
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user1    |
+      | user2    |
     When the administrator imports this ldif data:
       """
       dn: cn=so-far-unused-group-name,ou=TestUsers,dc=owncloud,dc=com
@@ -170,6 +192,7 @@ Feature: manage groups
 
   Scenario Outline: Add database group with same name as existing ldap group
     Given using OCS API version "<ocs-api-version>"
+    And group "grp1" has been created
     When the administrator sends a group creation request for group "grp1" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "<http-status-code>"

--- a/tests/acceptance/features/apiProvisioningLDAP/users.feature
+++ b/tests/acceptance/features/apiProvisioningLDAP/users.feature
@@ -80,6 +80,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin tries to modify displayname of user for which an LDAP attribute is specified
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     When the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to "ldap user"
     And the LDAP users are resynced
     When the administrator changes the display of user "user1" to "A New User" using the provisioning API
@@ -96,6 +97,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin tries to modify password of user for which an LDAP attribute is specified
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and skeleton files
     When the administrator sets the ldap attribute "userpassword" of the entry "uid=user1,ou=TestUsers" to "ldap_password"
     And the LDAP users are resynced
     And the administrator resets the password of user "user1" to "api_password" using the provisioning API
@@ -113,6 +115,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin tries to modify mail of user for which an LDAP attribute is specified
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     When the administrator sets the ldap attribute "mail" of the entry "uid=user1,ou=TestUsers" to "ldapuser@oc.com"
     And the LDAP users are resynced
     And the administrator changes the email of user "user1" to "apiuser@example.com" using the provisioning API
@@ -132,6 +135,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin tries to modify quota of user for which an LDAP attribute is specified
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     #to set Quota we can just misuse any LDAP text field
     And LDAP config "LDAPTestId" has key "ldapQuotaAttribute" set to "employeeNumber"
     When the administrator sets the ldap attribute "employeeNumber" of the entry "uid=user1,ou=TestUsers" to "10 MB"
@@ -152,6 +156,7 @@ Feature: Manage users using the Provisioning API
 
   Scenario Outline: admin sets quota of user for which no LDAP quota attribute is specified
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     #to set Quota we can just misuse any LDAP text field
     And LDAP config "LDAPTestId" has key "ldapQuotaAttribute" set to "employeeNumber"
     And the LDAP users have been resynced
@@ -169,6 +174,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin sets quota of user for which no LDAP quota attribute is specified but a default quota is set in the LDAP settings
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     #to set Quota we can just misuse any LDAP text field
     And LDAP config "LDAPTestId" has key "ldapQuotaAttribute" set to "employeeNumber"
     And LDAP config "LDAPTestId" has key "ldapQuotaDefault" set to "10MB"
@@ -189,6 +195,7 @@ Feature: Manage users using the Provisioning API
 
   Scenario Outline: admin sets quota of user in LDAP when a default quota is set in the LDAP settings
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     #to set Quota we can just misuse any LDAP text field
     And LDAP config "LDAPTestId" has key "ldapQuotaAttribute" set to "employeeNumber"
     And LDAP config "LDAPTestId" has key "ldapQuotaDefault" set to "10MB"
@@ -205,6 +212,7 @@ Feature: Manage users using the Provisioning API
   @issue-core-33186
   Scenario Outline: admin sets quota of user when the quota LDAP attribute is specified and a default quota is set in the LDAP settings
     Given using OCS API version "<ocs-api-version>"
+    And user "user1" has been created with default attributes and without skeleton files
     #to set Quota we can just misuse any LDAP text field
     And LDAP config "LDAPTestId" has key "ldapQuotaAttribute" set to "employeeNumber"
     And LDAP config "LDAPTestId" has key "ldapQuotaDefault" set to "10MB"
@@ -226,6 +234,7 @@ Feature: Manage users using the Provisioning API
 
   Scenario Outline: Administrator deletes a ldap user and resyncs again
     Given using OCS API version "<ocs-api-version>"
+    And user "user0" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "new file that should be overwritten after user deletion" to "textfile0.txt"
     When the administrator deletes user "user0" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
@@ -241,6 +250,7 @@ Feature: Manage users using the Provisioning API
 
   Scenario Outline: Administrator tries to create a user with same name as existing ldap user
     Given using OCS API version "<ocs-api-version>"
+    And user "user0" has been created with default attributes and skeleton files
     When the administrator sends a user creation request for user "user0" password "%alt1%" using the provisioning API
     Then the OCS status code should be "<ocs-status-code>"
     And the HTTP status code should be "<http-status-code>"

--- a/tests/acceptance/features/apiUserLDAP/moveUser.feature
+++ b/tests/acceptance/features/apiUserLDAP/moveUser.feature
@@ -5,6 +5,7 @@ Feature: move users between OUs
     Given the owncloud log level has been set to "info"
     And the owncloud log backend has been set to "owncloud"
     And the owncloud log has been cleared
+    And user "user0" has been created with default attributes and without skeleton files
     And user "user0" has uploaded file with content "new file that should still exist" to "textfile_new.txt"
     When the administrator deletes the ldap entry "uid=user0,ou=TestUsers"
     And the administrator imports this ldif data:

--- a/tests/acceptance/features/apiUserLDAPConnection/backupServerConnection.feature
+++ b/tests/acceptance/features/apiUserLDAPConnection/backupServerConnection.feature
@@ -8,6 +8,7 @@ So that user authentication still works when the main LDAP server is not reachab
   Background:
     Given the owncloud log level has been set to "warning"
     And the owncloud log has been cleared
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario: authentication works when the main server is not reachable but the backup server is
     Given LDAP config "LDAPTestId" has key "ldapHost" set to "not-existent"

--- a/tests/acceptance/features/apiUserLDAPConnection/groupFilter.feature
+++ b/tests/acceptance/features/apiUserLDAPConnection/groupFilter.feature
@@ -4,7 +4,18 @@ Feature: filter groups
   I want to be able to filter LDAP groups
   So that only groups meeting specific criteria are available in ownCloud
 
-    Scenario: single group filter
+  Background:
+    Given these groups have been created:
+      | groupname    |
+      | grp1         |
+      | grp2         |
+      | group1       |
+      | group2       |
+      | ShareeGroup  |
+      | ShareeGroup2 |
+
+
+  Scenario: single group filter
     When the administrator sets these settings of LDAP config "LDAPTestId" using the occ command
       | key             | value                                        |
       | ldapGroupFilter | (&(\|(objectclass=posixGroup))(\|(cn=grp2))) |
@@ -15,7 +26,7 @@ Feature: filter groups
       | admin   |
       | grp2    |
 
-    Scenario: filter with asterisk 
+  Scenario: filter with asterisk
     When the administrator sets these settings of LDAP config "LDAPTestId" using the occ command
       | key             | value                                           |
       | ldapGroupFilter | (&(\|(objectclass=posixGroup))(\|(cn=Sharee*))) |
@@ -27,7 +38,7 @@ Feature: filter groups
       | ShareeGroup  |
       | ShareeGroup2 |
 
-    Scenario: filter for multiple groups
+  Scenario: filter for multiple groups
     When the administrator sets these settings of LDAP config "LDAPTestId" using the occ command
       | key             | value                                                     |
       | ldapGroupFilter | (&(\|(objectclass=posixGroup))(\|(cn=group1)(cn=group2))) |
@@ -57,4 +68,3 @@ Feature: filter groups
         | group  |
         | admin  |
         | grp1   |
-

--- a/tests/acceptance/features/apiUserLDAPConnection/serverConnection.feature
+++ b/tests/acceptance/features/apiUserLDAPConnection/serverConnection.feature
@@ -4,6 +4,7 @@ Feature: connect to LDAP serer
   Background:
     Given the owncloud log level has been set to "warning"
     And the owncloud log has been cleared
+    And user "user0" has been created with default attributes and skeleton files
 
   Scenario: authentication fails when the configuration does not contain an ldap port
     Given LDAP config "LDAPTestId" has key "ldapPort" set to ""

--- a/tests/acceptance/features/apiUserLDAPSharing/sharingLocalUserLdapUser.feature
+++ b/tests/acceptance/features/apiUserLDAPSharing/sharingLocalUserLdapUser.feature
@@ -5,12 +5,14 @@ Feature: Sharing between local and LDAP users
 
   Background:
     Given user "local-user" has been created with default attributes in the database user backend
-    And these users have been initialized:
-    #these are LDAP users and are not initialized yet
+    And these users have been created with default attributes and skeleton files:
       | username |
       | user0    |
       | user1    |
       | user2    |
+    And group "grp1" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
 
   Scenario: Share a folder from an LDAP user to a local user
     When user "user0" shares folder "/PARENT" with user "local-user" using the sharing API

--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -26,6 +26,8 @@ use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use TestHelpers\SetupHelper;
+use Zend\Ldap\Exception\LdapException;
+use PHPUnit\Framework\Assert;
 
 require_once 'bootstrap.php';
 
@@ -33,36 +35,19 @@ require_once 'bootstrap.php';
  * context that holds all general steps for the user_ldap app
  */
 class UserLdapGeneralContext extends RawMinkContext implements Context {
-	private $oldConfig = [];
-	/**
-	 *
-	 * @var Zend\Ldap\Ldap
-	 */
-	private $ldap;
-	private $ldapAdminUser;
-	private $ldapAdminPassword;
-	private $ldapBaseDN;
-	private $ldapHost;
-	private $ldapPort;
-	private $ldapUsersOU;
-	private $ldapGroupsOU;
-	private $toDeleteDNs = [];
-	private $toDeleteLdapConfigs = [];
-	private $ldapCreatedUsers = [];
-	private $ldapCreatedGroups = [];
-
 	/**
 	 *
 	 * @var FeatureContext
 	 */
 	private $featureContext;
-	
+
 	/**
 	 * @Given a new LDAP config with the name :configId has been created
 	 *
 	 * @param string $configId
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function createNewLdapConfig($configId) {
 		$occResult = SetupHelper::runOcc(
@@ -73,9 +58,9 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 				"could not create empty LDAP config " . $occResult['stdErr']
 			);
 		}
-		$this->toDeleteLdapConfigs[] = $configId;
+		$this->featureContext->setToDeleteLdapConfigs($configId);
 	}
-	
+
 	/**
 	 * @Given LDAP config :configId has key :configKey set to :configValue
 	 * @When the administrator sets the LDAP config :configId key :configKey to :configValue using the occ command
@@ -85,11 +70,13 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $configValue
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function ldapConfigHasKeySetTo(
 		$configId, $configKey, $configValue
 	) {
-		if (!isset($this->oldConfig[$configId][$configKey])) {
+		$oldConfig = $this->featureContext->getOldLdapConfig();
+		if (!isset($oldConfig[$configId][$configKey])) {
 			//remember old settings to be able to set them back after test run
 			$occResult = SetupHelper::runOcc(
 				['ldap:show-config', $configId, "--output=json"]
@@ -101,12 +88,20 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 			}
 			$originalConfig = \json_decode($occResult['stdOut'], true);
 			if (isset($originalConfig[$configKey])) {
-				$this->oldConfig[$configId][$configKey] = $originalConfig[$configKey];
+				$this->featureContext->setOldLdapConfig(
+					$configId,
+					$configKey,
+					$originalConfig[$configKey]
+				);
 			} else {
-				$this->oldConfig[$configId][$configKey] = "";
+				$this->featureContext->setOldLdapConfig(
+					$configId,
+					$configKey,
+					""
+				);
 			}
 		}
-		$this->setLdapSetting($configId, $configKey, $configValue);
+		$this->featureContext->setLdapSetting($configId, $configKey, $configValue);
 	}
 
 	/**
@@ -117,28 +112,13 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param TableNode $table with the headings |key | value |
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function ldapConfigHasTheseSettings($configId, TableNode $table) {
 		foreach ($table as $line) {
 			$this->ldapConfigHasKeySetTo(
 				$configId, $line['key'], $line['value']
 			);
-		}
-	}
-
-	/**
-	 * @Given the LDAP users have been resynced
-	 * @When the LDAP users are resynced
-	 *
-	 * @throws Exception
-	 * @return void
-	 */
-	public function theLdapUsersHaveBeenResynced() {
-		$occResult = SetupHelper::runOcc(
-			['user:sync', 'OCA\User_LDAP\User_Proxy', '-m', 'remove']
-		);
-		if ($occResult['code'] !== "0") {
-			throw new \Exception("could not sync LDAP users " . $occResult['stdErr']);
 		}
 	}
 
@@ -151,15 +131,17 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param bool $append
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function setTheLdapAttributeOfTheEntryTo(
 		$attribute, $entry, $value, $append=false
 	) {
-		$ldapEntry = $this->ldap->getEntry($entry . "," . $this->ldapBaseDN);
+		$ldap = $this->featureContext->getLdap();
+		$ldapEntry = $ldap->getEntry($entry . "," . $this->featureContext->getLdapBaseDN());
 		Zend\Ldap\Attribute::setAttribute($ldapEntry, $attribute, $value, $append);
-		$this->ldap->update($entry . "," . $this->ldapBaseDN, $ldapEntry);
+		$ldap->update($entry . "," . $this->featureContext->getLdapBaseDN(), $ldapEntry);
 	}
-	
+
 	/**
 	 * @When the administrator sets the ldap attribute :attribute of the entry :entry to
 	 *
@@ -168,6 +150,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param TableNode $table
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function theLdapAttributeOfTheEntryToTable($attribute, $entry, $table) {
 		$first = true;
@@ -193,6 +176,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $filename
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function theLdapAttributeOfTheEntryToContentOfFile(
 		$attribute, $entry, $filename
@@ -212,6 +196,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $entry
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function addValueToLdapAttributeOfTheEntry($value, $attribute, $entry) {
 		$this->setTheLdapAttributeOfTheEntryTo($attribute, $entry, $value, true);
@@ -223,9 +208,11 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $entry
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function deleteTheLdapEntry($entry) {
-		$this->ldap->delete($entry . "," . $this->ldapBaseDN);
+		$ldap = $this->featureContext->getLdap();
+		$ldap->delete($entry . "," . $this->featureContext->getLdapBaseDN());
 	}
 
 	/**
@@ -236,10 +223,12 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $entry DN, not containing baseDN
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function deleteValueFromLdapAttribute($value, $attribute, $entry) {
-		$this->ldap->deleteAttributes(
-			$entry . "," . $this->ldapBaseDN, [$attribute => [$value]]
+		$ldap = $this->featureContext->getLdap();
+		$ldap->deleteAttributes(
+			$entry . "," . $this->featureContext->getLdapBaseDN(), [$attribute => [$value]]
 		);
 	}
 
@@ -252,70 +241,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function theAdminImportsThisLdifData(PyStringNode $ldifData) {
-		$this->importLdifData($ldifData->getRaw());
-	}
-
-	/**
-	 * @return \Zend\Ldap\Ldap
-	 */
-	public function getLdap() {
-		return $this->ldap;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapAdminUser() {
-		return $this->ldapAdminUser;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapAdminPassword() {
-		return $this->ldapAdminPassword;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapBaseDN() {
-		return $this->ldapBaseDN;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapHost() {
-		return $this->ldapHost;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapHostWithoutScheme() {
-		return $this->featureContext->removeSchemeFromUrl($this->ldapHost);
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapUsersOU() {
-		return $this->ldapUsersOU;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapGroupsOU() {
-		return $this->ldapGroupsOU;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLdapPort() {
-		return $this->ldapPort;
+		$this->featureContext->importLdifData($ldifData->getRaw());
 	}
 
 	/**
@@ -330,9 +256,11 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param string $ou
 	 *
 	 * @return void
+	 * @throws LdapException
 	 */
 	public function createLDAPUsers($amount, $prefix, $ou) {
-		$uidNumberSearch = $this->ldap->searchEntries(
+		$ldap = $this->featureContext->getLdap();
+		$uidNumberSearch = $ldap->searchEntries(
 			'objectClass=posixAccount', null, 0, ['uidNumber']
 		);
 		$maxUidNumber = 0;
@@ -342,20 +270,20 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 			}
 		}
 		$entry = [];
-		$ouDN = 'ou=' . $ou . ',' . $this->ldapBaseDN;
-		$ouExists = $this->ldap->exists($ouDN);
+		$ouDN = 'ou=' . $ou . ',' . $this->featureContext->getLdapBaseDN();
+		$ouExists = $ldap->exists($ouDN);
 		if (!$ouExists) {
 			$entry['objectclass'][] = 'top';
 			$entry['objectclass'][] = 'organizationalunit';
 			$entry['ou'] = $ou;
-			$this->ldap->add($ouDN, $entry);
-			$this->toDeleteDNs[] = $ouDN;
+			$ldap->add($ouDN, $entry);
+			$this->featureContext->setToDeleteDNs($ouDN);
 		}
 		
 		$lenOfSuffix = \strlen((string)$amount);
 		for ($i = 0; $i < $amount; $i++) {
 			$uid = $prefix . \str_pad($i, $lenOfSuffix, '0', STR_PAD_LEFT);
-			$newDN = 'uid=' . $uid . ',ou=' . $ou . ',' . $this->ldapBaseDN;
+			$newDN = 'uid=' . $uid . ',ou=' . $ou . ',' . $this->featureContext->getLdapBaseDN();
 			
 			$entry = [];
 			$entry['cn'] = $uid;
@@ -368,7 +296,7 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 			$entry['gidNumber'] = 5000;
 			$entry['uidNumber'] = $maxUidNumber + $i + 1;
 			
-			$this->ldap->add($newDN, $entry);
+			$ldap->add($newDN, $entry);
 			$this->featureContext->addUserToCreatedUsersList(
 				$uid, $uid, $uid, null, false
 			);
@@ -377,11 +305,11 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 				//if the OU did not exist, we have created it,
 				//and we will delete the OU recursive.
 				//No need to remember the entries to delete
-				$this->toDeleteDNs[] = $newDN;
+				$this->featureContext->setToDeleteDNs($newDN);
 			}
 		}
 	}
-	
+
 	/**
 	 * We need to make sure that the setup routines are called in the correct order
 	 * So this is the main function for setUp
@@ -391,222 +319,29 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @param BeforeScenarioScope $scope
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
 	public function setUpBeforeScenario(BeforeScenarioScope $scope) {
 		$environment = $scope->getEnvironment();
 		// Get all the contexts you need in this context
 		$this->featureContext = $environment->getContext('FeatureContext');
-		
-		$suiteParameters = SetupHelper::getSuiteParameters($scope);
-		$this->connectToLdap($suiteParameters);
-		$this->importLdifFile(
-			__DIR__ . (string)$suiteParameters['ldapInitialUserFilePath']
-		);
-		$this->theLdapUsersHaveBeenResynced();
 	}
 
 	/**
-	 * @param array $suiteParameters
+	 * @Then /^the users returned by the API should have$/
+	 *
+	 * @param TableNode $usersList
 	 *
 	 * @return void
+	 * @throws Exception
 	 */
-	public function connectToLdap($suiteParameters) {
-		SetupHelper::init(
-			$this->featureContext->getAdminUsername(),
-			$this->featureContext->getAdminPassword(),
-			$this->featureContext->getBaseUrl(),
-			$this->featureContext->getOcPath()
-		);
-		$occResult = SetupHelper::runOcc(
-			['ldap:show-config', 'LDAPTestId', '--output=json']
-		);
-		PHPUnit\Framework\Assert::assertSame(
-			'0', $occResult['code'],
-			"could not read current LDAP config. stdOut: " .
-			$occResult['stdOut'] .
-			" stdErr: " . $occResult['stdErr']
-		);
-
-		$ldapConfig = \json_decode(
-			$occResult['stdOut'], true
-		);
-		PHPUnit\Framework\Assert::assertNotNull(
-			$ldapConfig,
-			"could not json decode current LDAP config. stdOut: " . $occResult['stdOut']
-		);
-		$this->ldapBaseDN = (string)$ldapConfig['ldapBase'][0];
-		$this->ldapHost = (string)$ldapConfig['ldapHost'];
-		$this->ldapPort = (string)$ldapConfig['ldapPort'];
-		$this->ldapAdminUser = (string)$ldapConfig['ldapAgentName'];
-
-		$this->ldapAdminPassword = (string)$suiteParameters['ldapAdminPassword'];
-		$this->ldapUsersOU = (string)$suiteParameters['ldapUsersOU'];
-		$this->ldapGroupsOU = (string)$suiteParameters['ldapGroupsOU'];
-
-		$options = [
-			'host' => $this->ldapHost,
-			'port' => $this->ldapPort,
-			'password' => $this->ldapAdminPassword,
-			'bindRequiresDn' => true,
-			'baseDn' => $this->ldapBaseDN,
-			'username' => $this->ldapAdminUser
-		];
-		$this->ldap = new Zend\Ldap\Ldap($options);
-		$this->ldap->bind();
-	}
-
-	/**
-	 * imports an ldif string
-	 *
-	 * @param string $ldifData
-	 *
-	 * @return void
-	 */
-	public function importLdifData($ldifData) {
-		$items = Zend\Ldap\Ldif\Encoder::decode($ldifData);
-		if (isset($items['dn'])) {
-			//only one item in the ldif data
-			$this->ldap->add($items['dn'], $items);
-			if (isset($items['uid'])) {
-				$this->featureContext->addUserToCreatedUsersList(
-					$items['uid'][0],
-					$items['userpassword'][0]
-				);
-				\array_push($this->ldapCreatedUsers, $items['uid'][0]);
-			}
-			if (isset($items['objectclass']) && $items['objectclass'][0] === 'posixGroup') {
-				$this->featureContext->addGroupToCreatedGroupsList($items['cn'][0]);
-				\array_push($this->ldapCreatedGroups, $items['cn'][0]);
-			}
-		} else {
-			foreach ($items as $item) {
-				$this->ldap->add($item['dn'], $item);
-				if (isset($item['uid'])) {
-					$this->featureContext->addUserToCreatedUsersList(
-						$item['uid'][0],
-						$item['userpassword'][0]
-					);
-					\array_push($this->ldapCreatedUsers, $item['uid'][0]);
-				}
-				if (isset($item['objectclass']) && \in_array('posixGroup', $item['objectclass'])) {
-					$this->featureContext->addGroupToCreatedGroupsList($item['cn'][0]);
-					\array_push($this->ldapCreatedGroups, $item['cn'][0]);
-				}
-			}
-		}
-	}
-
-	/**
-	 *
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function importLdifFile($path) {
-		$ldifData = \file_get_contents($path);
-		$this->importLdifData($ldifData);
-	}
-
-	/**
-	 * @AfterScenario
-	 * @return void
-	 */
-	public function afterScenario() {
-		$this->resetOldConfig();
-		$this->deleteUserAndGroups();
-	}
-
-	/**
-	 * delete all imported ldap users and groups
-	 *
-	 * @return void
-	 */
-	public function deleteUserAndGroups() {
-		$this->ldap->delete(
-			"ou=" . $this->ldapUsersOU . "," . $this->ldapBaseDN, true
-		);
-		$this->ldap->delete(
-			"ou=" . $this->ldapGroupsOU . "," . $this->ldapBaseDN, true
-		);
-		foreach ($this->toDeleteDNs as $dn) {
-			$this->ldap->delete($dn, true);
-		}
-
-		foreach ($this->ldapCreatedUsers as $user) {
-			$this->featureContext->rememberThatUserIsNotExpectedToExist($user);
-		}
-		foreach ($this->ldapCreatedGroups as $group) {
-			$this->featureContext->rememberThatGroupIsNotExpectedToExist($group);
-		}
-
-		$this->theLdapUsersHaveBeenResynced();
-	}
-
-	/**
-	 * Sets back old settings
-	 *
-	 * @return void
-	 */
-	public function resetOldConfig() {
-		foreach ($this->toDeleteLdapConfigs as $configId) {
-			SetupHelper::runOcc(['ldap:delete-config', $configId]);
-		}
-		foreach ($this->oldConfig as $configId => $settings) {
-			foreach ($settings as $configKey => $configValue) {
-				$this->setLdapSetting($configId, $configKey, $configValue);
-			}
-		}
-	}
-
-	/**
-	 *
-	 * @param string $configId
-	 * @param string $configKey
-	 * @param string $configValue
-	 *
-	 * @throws \Exception
-	 * @return void
-	 */
-	public function setLdapSetting($configId, $configKey, $configValue) {
-		if ($configValue === "") {
-			$configValue = "''";
-		}
-		$substitutions = [
-			[
-				"code" => "%ldap_host_without_scheme%",
-				"function" => [
-					$this,
-					"getLdapHostWithoutScheme"
-				],
-				"parameter" => []
-			],
-			[
-				"code" => "%ldap_host%",
-				"function" => [
-					$this,
-					"getLdapHost"
-				],
-				"parameter" => []
-			],
-			[
-				"code" => "%ldap_port%",
-				"function" => [
-					$this,
-					"getLdapPort"
-				],
-				"parameter" => []
-			]
-		];
-		$configValue = $this->featureContext->substituteInLineCodes(
-			$configValue, [], $substitutions
-		);
-		$occResult = SetupHelper::runOcc(
-			['ldap:set-config', $configId, $configKey, $configValue]
-		);
-		if ($occResult['code'] !== "0") {
-			throw new \Exception(
-				"could not set LDAP setting " . $occResult['stdErr']
-			);
+	public function theUsersShouldHave($usersList) {
+		$this->featureContext->verifyTableNodeColumnsCount($usersList, 1);
+		$users = $usersList->getRows();
+		$usersSimplified = $this->featureContext->simplifyArray($users);
+		$respondedArray = $this->featureContext->getArrayOfUsersResponded($this->featureContext->getResponse());
+		foreach ($usersSimplified as $user) {
+			Assert::assertTrue(\in_array($user, $respondedArray));
 		}
 	}
 }

--- a/tests/acceptance/features/bootstrap/UserLdapUsersContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapUsersContext.php
@@ -36,7 +36,12 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	 * @var UserLdapGeneralContext
 	 */
 	private $userLdapGeneralContext;
-	
+
+	/**
+	 * @var FeatureContext
+	 */
+	private $featureContext;
+
 	/**
 	 * @When the administrator creates group :group in ldap OU :ou
 	 *
@@ -44,14 +49,15 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used
 	 *
 	 * @return void
+	 * @throws \Zend\Ldap\Exception\LdapException
 	 */
 	public function createLdapGroup($group, $ou = null) {
 		if ($ou === null) {
-			$ou = $this->userLdapGeneralContext->getLdapGroupsOU();
+			$ou = $this->featureContext->getLdapGroupsOU();
 		}
 		
 		$newDN = 'cn=' . $group . ',ou=' . $ou . ',' .
-				 $this->userLdapGeneralContext->getLdapBaseDN();
+				 $this->featureContext->getLdapBaseDN();
 		
 		$entry = [];
 		$entry['cn'] = $group;
@@ -59,9 +65,9 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 		$entry['objectclass'][] = 'top';
 		$entry['gidNumber'] = 5000;
 		
-		$this->userLdapGeneralContext->getLdap()->add($newDN, $entry);
+		$this->featureContext->getLdap()->add($newDN, $entry);
 	}
-	
+
 	/**
 	 * @When the administrator adds user :user to ldap group :group
 	 * @When the administrator adds user :user to group :group in ldap OU :ou
@@ -71,17 +77,21 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used
 	 *
 	 * @return void
+	 * @throws \Zend\Ldap\Exception\LdapException
 	 */
 	public function addUserToLdapGroup($user, $group, $ou = null) {
 		if ($ou === null) {
-			$ou = $this->userLdapGeneralContext->getLdapGroupsOU();
+			$ou = $this->featureContext->getLdapGroupsOU();
 		}
 		
 		$this->userLdapGeneralContext->addValueToLdapAttributeOfTheEntry(
 			$user, "memberUid", "cn=$group,ou=$ou"
 		);
+		$this->featureContext->theLdapUsersHaveBeenReSynced();
+		// To sync new ldap groups
+		$this->featureContext->runOcc(['group:list -vvv']);
 	}
-	
+
 	/**
 	 * @When the administrator removes user :user from ldap group :group
 	 * @When the administrator removes user :user from group :group in ldap OU :ou
@@ -91,10 +101,11 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used
 	 *
 	 * @return void
+	 * @throws \Zend\Ldap\Exception\LdapException
 	 */
 	public function removeUserFromLdapGroup($user, $group, $ou = null) {
 		if ($ou === null) {
-			$ou = $this->userLdapGeneralContext->getLdapGroupsOU();
+			$ou = $this->featureContext->getLdapGroupsOU();
 		}
 		$this->userLdapGeneralContext->deleteValueFromLdapAttribute(
 			$user, "memberUid", "cn=$group,ou=$ou"
@@ -109,10 +120,11 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 	 * @param string $ou if null ldapGroupsOU from behat.yml will be used
 	 *
 	 * @return void
+	 * @throws \Zend\Ldap\Exception\LdapException
 	 */
 	public function deleteLdapGroup($group, $ou = null) {
 		if ($ou === null) {
-			$ou = $this->userLdapGeneralContext->getLdapGroupsOU();
+			$ou = $this->featureContext->getLdapGroupsOU();
 		}
 		$this->userLdapGeneralContext->deleteTheLdapEntry("cn=$group,ou=$ou");
 	}
@@ -129,6 +141,9 @@ class UserLdapUsersContext extends RawMinkContext implements Context {
 		// Get all the contexts you need in this context
 		$this->userLdapGeneralContext = $environment->getContext(
 			'UserLdapGeneralContext'
+		);
+		$this->featureContext = $environment->getContext(
+			'FeatureContext'
 		);
 	}
 }

--- a/tests/acceptance/features/cliProvisioning/users.feature
+++ b/tests/acceptance/features/cliProvisioning/users.feature
@@ -5,6 +5,12 @@ Feature: add a user using the using the occ command
   I want to be able to add, delete and modify users via the command line
   So that I can easily manage users when user LDAP is enabled
 
+  Background:
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+
   Scenario: admin creates an ordinary user using the occ command
     When the administrator creates this user using the occ command:
       | username  |

--- a/tests/acceptance/features/webUIProvisioning/groups.feature
+++ b/tests/acceptance/features/webUIProvisioning/groups.feature
@@ -5,8 +5,16 @@ Feature: add group
   So that I can easily manage groups when user LDAP is enabled
 
   Background:
+    And these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+      | user2    |
+    And group "grp1" has been created
     # In drone the ldap groups have not synced yet. So this occ command is required to sync them.
-    Given the administrator has invoked occ command "group:list"
+    And the administrator has invoked occ command "group:list"
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
     And user admin has logged in using the webUI
     And the administrator has browsed to the users page
 

--- a/tests/acceptance/features/webUIProvisioning/users.feature
+++ b/tests/acceptance/features/webUIProvisioning/users.feature
@@ -5,7 +5,11 @@ Feature: add users
   So that I can easily manage users when user LDAP is enabled
 
   Background:
-    Given user admin has logged in using the webUI
+    Given these users have been created with default attributes and skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+    And user admin has logged in using the webUI
     And the administrator has browsed to the users page
 
   Scenario: use the webUI to create a simple user

--- a/tests/acceptance/features/webUIUserLDAP/avatar.feature
+++ b/tests/acceptance/features/webUIUserLDAP/avatar.feature
@@ -5,6 +5,9 @@ Feature: providing an avatar by LDAP
   I want to see my avatar from LDAP being used in owncloud
   So that other users can recognize me by my picture
 
+  Background:
+    Given user "user2" has been created with default attributes and without skeleton files
+
   @skip @issue-198 #we cannot revert this even with deleting the user
   Scenario: upload an avatar to the LDAP server
     When the administrator sets the ldap attribute "jpegPhoto" of the entry "uid=user2,ou=TestUsers" to the content of the file "testavatar.jpg"

--- a/tests/acceptance/features/webUIUserLDAP/changingDisplayName.feature
+++ b/tests/acceptance/features/webUIUserLDAP/changingDisplayName.feature
@@ -5,6 +5,9 @@ Feature: changing display name
   I want the display name in owncloud to correspond with the one in LDAP
   So that users can be found by their LDAP names
 
+  Background:
+    Given user "user1" has been created with default attributes and without skeleton files
+
   Scenario Outline: change display name on the LDAP server
     Given the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to "<new-displayname>"
     When user "user1" logs in using the webUI
@@ -22,7 +25,8 @@ Feature: changing display name
     Then "0" should be shown as the name of the current user on the WebUI
 
   Scenario: delete display name on the LDAP server
-    Given the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to ""
+    Given user "user2" has been created with default attributes and without skeleton files
+    And the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to ""
     When user "user1" logs in using the webUI
     Then "user1" should be shown as the name of the current user on the WebUI
     When the user re-logs in as "user2" using the webUI

--- a/tests/acceptance/features/webUIUserLDAP/changingPassword.feature
+++ b/tests/acceptance/features/webUIUserLDAP/changingPassword.feature
@@ -6,6 +6,7 @@ Feature: changing password
   So that I do not have to remember multiple passwords
 
   Scenario Outline: change password on the LDAP server
+    Given user "user1" has been created with default attributes and without skeleton files
     When the administrator sets the ldap attribute "userpassword" of the entry "uid=user1,ou=TestUsers" to "<new-password>"
     Then it should not be possible to login with the username "user1" and password "%alt1%" using the WebUI
     But it should be possible to login with the username "user1" and password "<new-password>" using the WebUI

--- a/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
+++ b/tests/acceptance/features/webUIUserLDAP/groupMembership.feature
@@ -11,6 +11,12 @@ Feature: group membership
       | user1    |
       | user2    |
       | user3    |
+      | user4    |
+    And group "grp1" has been created
+    And group "grp3" has been created
+    And user "user1" has been added to group "grp1"
+    And user "user2" has been added to group "grp1"
+    And user "user3" has been added to group "grp3"
     And user "user1" has logged in using the webUI
 
   @skipOnOcV10.2
@@ -81,10 +87,6 @@ Feature: group membership
     # Ensure that the test code is aware of the users and groups that exist
     Given these users have been created with default attributes and skeleton files but not initialized:
       | username |
-      | user1    |
-      | user2    |
-      | user3    |
-      | user4    |
       | usergrp  |
     And these groups have been created:
       | groupname |
@@ -92,9 +94,7 @@ Feature: group membership
       | group2    |
       | group3    |
       | groupuser |
-      | grp1      |
       | grp2      |
-      | grp3      |
       | grpuser   |
     And the administrator sets the ldap attribute "description" of the entry "cn=grp1,ou=TestGroups" to "my first group"
     And the user has opened the share dialog for folder "simple-folder"

--- a/tests/acceptance/features/webUIUserLDAP/loginUsingEmailAddress.feature
+++ b/tests/acceptance/features/webUIUserLDAP/loginUsingEmailAddress.feature
@@ -5,6 +5,9 @@ Feature: login users
   I want users to login with their email address stored on a LDAP server
   So that they only need to remember one username and password (SSO)
 
+  Background:
+    Given user "user1" has been created with default attributes and without skeleton files
+
   Scenario: login with default settings
     When the LDAP users have been resynced
     Then it should be possible to login with the username "user1@example.org" and password "%alt1%" using the WebUI
@@ -50,6 +53,7 @@ Feature: login users
     Then it should be possible to login with the username "user1-change@example.org" and password "%alt1%" using the WebUI
 
   Scenario: delete the Email address
+    Given user "user2" has been created with default attributes and without skeleton files
     When the administrator sets the ldap attribute "mail" of the entry "uid=user1,ou=TestUsers" to ""
     And the LDAP users have been resynced
     Then it should not be possible to login with the username "user1@example.org" and password "%alt1%" using the WebUI

--- a/tests/acceptance/features/webUIUserLDAP/paging.feature
+++ b/tests/acceptance/features/webUIUserLDAP/paging.feature
@@ -1,4 +1,4 @@
-@insulated @disablePreviews
+@insulated @disablePreviews @webUI
 Feature: paging
 
   As an admin


### PR DESCRIPTION
## Description
It was a bit annoying to interact with zend-ldap from user_ldap tests.

Setups and configuration for ldap-connection has been migrated to core tests!