### PR TITLE
add user sync tests

### DIFF
--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -123,6 +123,33 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @When LDAP user :user is resynced
+	 *
+	 * @param string $user
+	 *
+	 * @throws Exception
+	 * @return void
+	 */
+	public function ldapUserIsSynced($user) {
+		$occResult = SetupHelper::runOcc(
+			['user:sync', 'OCA\User_LDAP\User_Proxy', '-u', $user, '-m', 'remove']
+		);
+		if ($occResult['code'] !== "0") {
+			throw new \Exception("could not sync LDAP user {$user} " . $occResult['stdErr']);
+		}
+	}
+
+	/**
+	 * @When the admin lists the enabled user backends using the occ command
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdminListsTheEnabledBackendsUsingTheOccCommand() {
+		$this->featureContext->runOcc(["user:sync -l"]);
+	}
+	
+	/**
 	 * @When the administrator sets the ldap attribute :attribute of the entry :entry to :value
 	 *
 	 * @param string $attribute

--- a/tests/acceptance/features/cliProvisioning/userSync.feature
+++ b/tests/acceptance/features/cliProvisioning/userSync.feature
@@ -1,0 +1,41 @@
+@cli
+Feature: sync a user using occ command
+
+  As an administrator
+  I want to be able to sync a user via the command line
+  So that I can easily manage users when user LDAP is enabled
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | user0    |
+      | user1    |
+
+  @skipOnOcV10.3
+  Scenario: admin deletes ldap users and syncs only one of them
+    When the administrator deletes user "user0" using the occ command
+    And the administrator deletes user "user1" using the occ command
+    Then user "user0" should not exist
+    And user "user1" should not exist
+    When LDAP user "user0" is resynced
+    Then user "user0" should exist
+    And user "user1" should not exist
+
+  @skipOnOcV10.3
+  Scenario: admin edits ldap users email and syncs only one of them
+    When the administrator changes the email of user "user0" to "user0@example0.com" using the occ command
+    And the administrator changes the email of user "user1" to "user1@example1.com" using the occ command
+    Then user "user0" should exist
+    And user "user1" should exist
+    When LDAP user "user0" is resynced
+    Then the email address of user "user0" should be "user0@example.org"
+    And the email address of user "user1" should be "user1@example1.com"
+
+  Scenario: admin lists all the enabled backends
+    When the admin lists the enabled user backends using the occ command
+    Then the command should have been successful
+    And the command output should be:
+      """
+      OC\User\Database
+      OCA\User_LDAP\User_Proxy
+      """


### PR DESCRIPTION
### Description
- Adds test for `user:sync` of a particular user.
- On top of https://github.com/owncloud/core/pull/36790/files

### Related Issues
https://github.com/owncloud/core/issues/33293