### PR TITLE
[Test_Only] Added acceptance test for single/multiple user:sync

### DIFF
--- a/tests/acceptance/features/cliProvisioning/userSync.feature
+++ b/tests/acceptance/features/cliProvisioning/userSync.feature
@@ -1,8 +1,8 @@
 @cli
-Feature: sync a user using occ command
+Feature: sync user using occ command
 
   As an administrator
-  I want to be able to sync a user via the command line
+  I want to be able to sync user/users via the command line
   So that I can easily manage users when user LDAP is enabled
 
   Background:
@@ -39,3 +39,19 @@ Feature: sync a user using occ command
       OC\User\Database
       OCA\User_LDAP\User_Proxy
       """
+
+  Scenario: admin deletes ldap users and performs full sync
+    When the administrator deletes user "user0" using the occ command
+    And the administrator deletes user "user1" using the occ command
+    Then user "user0" should not exist
+    And user "user1" should not exist
+    When the LDAP users have been resynced
+    Then user "user0" should exist
+    And user "user1" should exist
+
+  Scenario: sync a local user
+    Given user "local-user" has been created with default attributes in the database user backend
+    When the administrator changes the display name of user "local-user" to "Test User" using the occ command
+    And LDAP user "local-user" is resynced
+    Then the command should have been successful
+    And user "local-user" should not exist


### PR DESCRIPTION
## Description
Acceptance tests added for `user:sync` command covering:
- defalt full users sync
- sync a local user

## Related Issue
https://github.com/owncloud/core/issues/36597
https://github.com/owncloud/core/issues/33293

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
