### PR TITLE
[Tests-Only] Added acceptance tests for user:sync command with super/sub-strings in user usernames

### DIFF
--- a/tests/acceptance/features/cliProvisioning/userSync.feature
+++ b/tests/acceptance/features/cliProvisioning/userSync.feature
@@ -55,3 +55,29 @@ Feature: sync user using occ command
     And LDAP user "local-user" is resynced
     Then the command should have been successful
     And user "local-user" should not exist
+
+  @skipOnOcV10.3
+  Scenario: sync a ldap user that is substring of some other ldap users
+    Given these users have been created with default attributes and without skeleton files:
+      | username    |
+      | regularuser |
+      | regular     |
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=regular,ou=TestUsers" to "Test User"
+    And LDAP user "regular" is resynced
+    Then user "regular" should exist
+    And user "regularuser" should exist
+    And the display name of user "regular" should be "Test User"
+    And the display name of user "regularuser" should be "Regular User"
+
+  @skipOnOcV10.3
+  Scenario: sync a ldap user that is superstring of some other ldap users
+    Given these users have been created with default attributes and without skeleton files:
+      | username    |
+      | regularuser |
+      | regular     |
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=regularuser,ou=TestUsers" to "Test User"
+    And LDAP user "regularuser" is resynced
+    Then user "regular" should exist
+    And user "regularuser" should exist
+    And the display name of user "regularuser" should be "Test User"
+    And the display name of user "regular" should be "Regular User"


### PR DESCRIPTION
## Description
Acceptance tests added for `user:sync` command covering:
- sync a user that is a substring of some other LDAP user
- sync a user that is a substring and superstring of some local user


## Related Issue
https://github.com/owncloud/core/issues/36597
https://github.com/owncloud/core/issues/33293

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
