### PR TITLE
[Tests-Only] Added acceptance test for user:sync with non-existing user

### DIFF
--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -131,10 +131,10 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function ldapUserIsSynced($user) {
-		$occResult = SetupHelper::runOcc(
+		$this->featureContext->runOcc(
 			['user:sync', 'OCA\User_LDAP\User_Proxy', '-u', $user, '-m', 'remove']
 		);
-		if ($occResult['code'] !== "0") {
+		if ($this->featureContext->getExitStatusCodeOfOccCommand() !== 0) {
 			throw new \Exception("could not sync LDAP user {$user} " . $occResult['stdErr']);
 		}
 	}

--- a/tests/acceptance/features/cliProvisioning/userSync.feature
+++ b/tests/acceptance/features/cliProvisioning/userSync.feature
@@ -85,7 +85,6 @@ Feature: sync user using occ command
 
   @issue-515
   Scenario: sync a user that does not exist
-    Given user "regularuser" should not exist
     When LDAP user "regularuser" is resynced
     Then the command should have been successful
     And the command output should be:

--- a/tests/acceptance/features/cliProvisioning/userSync.feature
+++ b/tests/acceptance/features/cliProvisioning/userSync.feature
@@ -82,3 +82,15 @@ Feature: sync user using occ command
     And user "regularuser" should exist
     And the display name of user "regularuser" should be "Test User"
     And the display name of user "regular" should be "Regular User"
+
+  @issue-515
+  Scenario: sync a user that does not exist
+    Given user "regularuser" should not exist
+    When LDAP user "regularuser" is resynced
+    Then the command should have been successful
+    And the command output should be:
+      """
+      Syncing regularuser ...
+      Deleting accounts:
+      regularuser, ,  (no longer exists in the backend)
+      """


### PR DESCRIPTION
## Description
Added acceptance test for occ command `user:sync` for a non-existing user

## Related Issue
- Reproduces https://github.com/owncloud/user_ldap/issues/515
- Part of https://github.com/owncloud/core/issues/36597