### PR TITLE
fix make clean so it cleans vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ clean: clean-composer-deps clean-dist clean-build
 
 .PHONY: clean-composer-deps
 clean-composer-deps:
+	rm -Rf vendor
 	rm -Rf vendor-bin/**/vendor vendor-bin/**/composer.lock
 
 #


### PR DESCRIPTION
I was doing `make clean` in this app and realised that it was not removing the `vendor` stuff like is the behaviour of `make clean` in the other apps.

Adjust the `clean` Makefile target to be like other apps.