### PR TITLE
Put back zend-ldap dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
         }
     },
     "require-dev": {
-        "bamarni/composer-bin-plugin": "^1.2"
+        "bamarni/composer-bin-plugin": "^1.2",
+        "zendframework/zend-ldap": "^2.8"
     },
     "require": {
         "php": ">=7.0.8",


### PR DESCRIPTION
It was accidentally removed in PR #495 
A new `composer.lock` was not generated, so the removal had no real effect (yet).
I noticed it in https://github.com/owncloud/user_ldap/pull/523#issuecomment-591516241

Note: after putting this back, I will then make another PR to switch to `laminas-ldap`