### PR TITLE
Set core min_version to 10.3 with PHP min of 7.1

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -25,7 +25,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 	<screenshot>https://raw.githubusercontent.com/owncloud/screenshots/master/user_ldap/ownCloud-app-ldap-user-management.jpg</screenshot>
 	<dependencies>
 		<lib>ldap</lib>
-		<owncloud min-version="10.4" max-version="10" />
+		<owncloud min-version="10.3" max-version="10" />
 	</dependencies>
 
 	<namespace>User_LDAP</namespace>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "platform": {
-            "php": "7.0.8"
+            "php": "7.1.3"
         }
     },
     "require-dev": {
@@ -9,7 +9,7 @@
         "laminas/laminas-ldap": "^2.8"
     },
     "require": {
-        "php": ">=7.0.8",
+        "php": ">=7.1.3",
         "ext-ldap": "*"
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "0668b30f02641c0716b0a3b3bae64a6e",
+    "content-hash": "b169d780b58f700f2be4997dafdd95b5",
     "packages": [],
     "packages-dev": [
         {
@@ -48,16 +48,16 @@
         },
         {
             "name": "laminas/laminas-ldap",
-            "version": "2.10.1",
+            "version": "2.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-ldap.git",
-                "reference": "52d67bbe6095da4e7e3578407e44322a6d7874ce"
+                "reference": "649fae8982149b93071c4a7d56f2c4efeed51aa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-ldap/zipball/52d67bbe6095da4e7e3578407e44322a6d7874ce",
-                "reference": "52d67bbe6095da4e7e3578407e44322a6d7874ce",
+                "url": "https://api.github.com/repos/laminas/laminas-ldap/zipball/649fae8982149b93071c4a7d56f2c4efeed51aa8",
+                "reference": "649fae8982149b93071c4a7d56f2c4efeed51aa8",
                 "shasum": ""
             },
             "require": {
@@ -66,7 +66,7 @@
                 "php": "^5.6 || ^7.0"
             },
             "replace": {
-                "zendframework/zend-ldap": "self.version"
+                "zendframework/zend-ldap": "^2.10.1"
             },
             "require-dev": {
                 "laminas/laminas-coding-standard": "~1.0.0",
@@ -74,7 +74,7 @@
                 "laminas/laminas-eventmanager": "^2.6.3 || ^3.0.1",
                 "laminas/laminas-stdlib": "^2.7 || ^3.0",
                 "php-mock/php-mock-phpunit": "^1.1.2 || ^2.1.1",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20"
             },
             "suggest": {
                 "laminas/laminas-eventmanager": "Laminas\\EventManager component"
@@ -101,20 +101,20 @@
                 "laminas",
                 "ldap"
             ],
-            "time": "2019-12-31T17:15:47+00:00"
+            "time": "2020-03-29T13:06:47+00:00"
         },
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d"
+                "reference": "bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/0fb9675b84a1666ab45182b6c5b29956921e818d",
-                "reference": "0fb9675b84a1666ab45182b6c5b29956921e818d",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9",
+                "reference": "bfbbdb6c998d50dbf69d2187cb78a5f1fa36e1e9",
                 "shasum": ""
             },
             "require": {
@@ -153,7 +153,7 @@
                 "laminas",
                 "zf"
             ],
-            "time": "2020-01-07T22:58:31+00:00"
+            "time": "2020-04-03T16:01:00+00:00"
         }
     ],
     "aliases": [],
@@ -162,11 +162,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.0.8",
+        "php": ">=7.1.3",
         "ext-ldap": "*"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.8"
+        "php": "7.1.3"
     }
 }


### PR DESCRIPTION
We could allow user_ldap with core 10.3.2 still, if we want. It should work fine.
It is only #490 "Allow plus in LDAP usernames" that will cause an issue if someone has user_ldap with core 10.3.2 and then does create an LDAP username that contains a `+` sign.

Note: we should do the `composer.json` change at some time anyway. If this PR  does not happen, then I will do that to `master` for some later release.