### PR TITLE
Add scenario to check a variety of user names in LDAP

### DIFF
--- a/tests/acceptance/features/apiUserLDAP/specialUsernames.feature
+++ b/tests/acceptance/features/apiUserLDAP/specialUsernames.feature
@@ -1,0 +1,21 @@
+@api
+Feature: User names that are valid in ownCloud can be created and used from LDAP
+  As an administrator
+  I want the full range of valid ownCloud user names to work from LDAP
+  So that LDAP users can work with their files in ownCloud
+
+  Scenario Outline: Valid ownCloud user names can be used from LDAP
+    Given user "<username>" has been created with default attributes and without skeleton files
+    When user "<username>" uploads file with content "uploaded content" to "test.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And user "<username>" should exist
+    And the content of file "test.txt" for user "<username>" should be "uploaded content"
+    And user "<username>" should be able to delete file "test.txt"
+    Examples:
+      | username              |
+      | JohnSmith             |
+      | dash-user             |
+      | under_score           |
+      | some.one@example.com  |
+      | jack+jill             |
+      | jack+jill@example.com |


### PR DESCRIPTION
PR #490 allowed `+` in LDAP usernames. There are a variety of valid characters in valid ownCloud usernames. Any of those should work when they come from LDAP.

We currently run the core acceptance tests with LDAP enabled. When run in that environment, they create the user(s) in LDAP, sync them and run the test scenario. But those tests mostly use "easy" usernames. The ones that check the "edge case" usernames are specifically using the provisioning API and not going via LDAP.

This PR adds a specific scenario to the LDAP suite that creates "edge case" usernames in LDAP and checks that the user can do the basic upload/download/delete operations.