### PR TITLE
Remove ldapInitialUserFilePath reference to ldap-users.ldif

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -11,7 +11,6 @@ default:
           ldapAdminPassword: admin
           ldapUsersOU: TestUsers
           ldapGroupsOU: TestGroups
-          ldapInitialUserFilePath: /../../../../tests/acceptance/config/ldap-users.ldif
       contexts:
         - UserLdapGeneralContext:
         - UserLdapUsersContext:


### PR DESCRIPTION
Part of issue #250

`ldapInitialUserFilePath` is not used anywhere anymore. Remove it to avoid confusion.

Note: `ldap-users.ldif` file is also not used any more. I have left it there for now as an example `ldif` file that developers-testers can copy-paste from. But maybe it should be deleted, edited, renamed, or? To avoid confusion in the future for people who might think it is actually used in the tests.
