### PR TITLE
Rename example-ldap-users-groups.ldif

### DIFF
--- a/tests/acceptance/config/example-ldap-users-groups.ldif
+++ b/tests/acceptance/config/example-ldap-users-groups.ldif
@@ -1,3 +1,9 @@
+# This LDIF file contains examples of groups and users that could be created
+# in LDAP when testing. It is not used by the automated tests. The automated
+# tests create LDAP groups and users on-the-fly.
+#
+# Examples here might be useful if you are manually setting up some LDAP entries
+# for local development and testing.
 dn: ou=TestGroups,dc=owncloud,dc=com
 objectclass: top
 objectclass: organizationalUnit


### PR DESCRIPTION
This LDIF file is not used any more. The automated tests use the LDIF  file in core to just create the `TestGroups` and `TestUsers` Organizational Units, and actual groups and users are added to LDAP on-the-fly as the tests need them.

Rename this file and add comments to the top so that it is clear to future readers that it is just an example of "hopefully useful" LDIF entries.