### PR TITLE
Reissue search in case of missing cookie in continued paged search

### DIFF
--- a/tests/integration/setup-scripts/createExplicitUsers.php
+++ b/tests/integration/setup-scripts/createExplicitUsers.php
@@ -51,7 +51,7 @@ if (true) {
 	}
 }
 
-$users = ['alice', 'boris'];
+$users = ['alice', 'boris', 'carl'];
 
 foreach ($users as $uid) {
 	$newDN = 'uid=' . $uid . ',' . $ouDN;


### PR DESCRIPTION
Commit https://github.com/owncloud/user_ldap/commit/f4dc061a22af1a04bdbcfbe859dec277911e0ba9#diff-082c8dddc0cb46139a939a52fae88490R1959-R1960 removed user_ldap app capability to refetch cookie for continued paged search. This PR brings functionality back as it is required for correct handling of search with cookies - https://docs.microsoft.com/en-us/windows-server/identity/ad-ds/manage/how-ldap-server-cookies-are-handled.

- [x] refetch cookie for continued paged search via reissuing search with 'skipHandling'.
- [x] manual tests
- [x] `skipHandling=false` is expensive, improve performance
- [x] adjust tests

Fixes https://github.com/owncloud/enterprise/issues/3731