### PR TITLE
[Tests-Only] Bump phpstan to 0.12

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^0.10.2"
+        "phpstan/phpstan": "^0.12"
     }
 }


### PR DESCRIPTION
Related - owncloud/QA#642

Update phpstan to 0.12

Note: `phpstan` is not actually running yet in this repo. This PR just updates the required version for when it does get run.

PR #547 has code changes that were trying to get it running and passing. But there is too much change needed there. That needs to be finished some other time when effort is scheduled.