### PR TITLE
[Tests-Only] Added test scenarios for single user sync using OCS API

### DIFF
--- a/tests/acceptance/features/apiProvisioningLDAP/userSync.feature
+++ b/tests/acceptance/features/apiProvisioningLDAP/userSync.feature
@@ -25,12 +25,14 @@ Feature: Single user sync using the OCS API
 
   Scenario Outline: admin syncs after changing display name of a ldap user
     Given using OCS API version "<ocs-api-version>"
-    When the administrator sets the ldap attribute "displayname" of the entry "uid=user0,ou=TestUsers" to "ldap user"
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=user0,ou=TestUsers" to "ldap user zero"
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=user1,ou=TestUsers" to "ldap user one"
     And the administrator tries to sync user "user0" using the OCS API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status-code>"
     And user "user0" should exist
-    And the display name of user "user0" should be "ldap user"
+    And the display name of user "user0" should be "ldap user zero"
+    And the display name of user "user1" should be "User One"
     Examples:
       | ocs-api-version | ocs-status-code |
       | 1               | 100             |
@@ -38,12 +40,14 @@ Feature: Single user sync using the OCS API
 
   Scenario Outline: admin syncs after changing email address of a ldap user
     Given using OCS API version "<ocs-api-version>"
-    When the administrator sets the ldap attribute "mail" of the entry "uid=user0,ou=TestUsers" to "ldapuser@example.com"
+    When the administrator sets the ldap attribute "mail" of the entry "uid=user0,ou=TestUsers" to "ldapuser0@example.com"
+    When the administrator sets the ldap attribute "mail" of the entry "uid=user1,ou=TestUsers" to "ldapuser1@example.com"
     And the administrator tries to sync user "user0" using the OCS API
     Then the HTTP status code should be "200"
     And the OCS status code should be "<ocs-status-code>"
     And user "user0" should exist
-    And the email address of user "user0" should be "ldapuser@example.com"
+    And the email address of user "user0" should be "ldapuser0@example.com"
+    And the email address of user "user1" should be "user1@example.org"
     Examples:
       | ocs-api-version | ocs-status-code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiProvisioningLDAP/userSync.feature
+++ b/tests/acceptance/features/apiProvisioningLDAP/userSync.feature
@@ -22,3 +22,29 @@ Feature: Single user sync using the OCS API
       | ocs-api-version | ocs-status-code |
       | 1               | 100             |
       | 2               | 200             |
+
+  Scenario Outline: admin syncs after changing display name of a ldap user
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator sets the ldap attribute "displayname" of the entry "uid=user0,ou=TestUsers" to "ldap user"
+    And the administrator tries to sync user "user0" using the OCS API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-status-code>"
+    And user "user0" should exist
+    And the display name of user "user0" should be "ldap user"
+    Examples:
+      | ocs-api-version | ocs-status-code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  Scenario Outline: admin syncs after changing email address of a ldap user
+    Given using OCS API version "<ocs-api-version>"
+    When the administrator sets the ldap attribute "mail" of the entry "uid=user0,ou=TestUsers" to "ldapuser@example.com"
+    And the administrator tries to sync user "user0" using the OCS API
+    Then the HTTP status code should be "200"
+    And the OCS status code should be "<ocs-status-code>"
+    And user "user0" should exist
+    And the email address of user "user0" should be "ldapuser@example.com"
+    Examples:
+      | ocs-api-version | ocs-status-code |
+      | 1               | 100             |
+      | 2               | 200             |


### PR DESCRIPTION
### Description
:heavy_check_mark: tests scenarios for single user sync using OCS API are added

### Related issue:
Fixes #563 