### PR TITLE
Add warning for disabling email login regarding strict login check

### DIFF
--- a/templates/part.wizard-loginfilter.php
+++ b/templates/part.wizard-loginfilter.php
@@ -18,7 +18,7 @@
 			</label>
 
 			<input type="checkbox" id="ldap_loginfilter_email"
-				   title="<?php p($l->t('Allows login against an email attribute. Mail and mailPrimaryAddress will be allowed.'));?>"
+				   title="<?php p($l->t('Allows login against an email attribute. Mail and mailPrimaryAddress will be allowed. WARNING: Disabling login with email might require enabling strict login checking to be effective, please refer to ownCloud documentation for more details!'));?>"
 				   name="ldap_loginfilter_email" value="1" />
 		</p>
 		<p>


### PR DESCRIPTION
Adds a warning that this config is not effective if strict checking is not enabled. Requires  https://github.com/owncloud/core/pull/37569

<img width="607" alt="image" src="https://user-images.githubusercontent.com/13368647/85260059-5beccc80-b46a-11ea-8df8-29f57a061393.png">

