### PR TITLE
[Tests-Only] Run only smokeTest for core-webui-acceptance-encryption-userkeys-nightly

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -663,7 +663,7 @@ config = {
 			'cron': 'nightly',
 			'runAllSuites': True,
 			'numberOfParts': 5,
-			'filterTags': '~@skipOnEncryption&&~@skipOnEncryptionType:user-keys',
+			'filterTags': '@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys',
 			'extraApps': {
 				'encryption': ''
 			},

--- a/.drone.yml
+++ b/.drone.yml
@@ -29252,7 +29252,7 @@ steps:
   - . /var/www/owncloud/saved-settings.sh
   - make test-acceptance-core-webui
   environment:
-    BEHAT_FILTER_TAGS: ~@skipOnEncryption&&~@skipOnEncryptionType:user-keys
+    BEHAT_FILTER_TAGS: "@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys"
     BROWSER: chrome
     DIVIDE_INTO_NUM_PARTS: 5
     MAILHOG_HOST: email
@@ -29475,7 +29475,7 @@ steps:
   - . /var/www/owncloud/saved-settings.sh
   - make test-acceptance-core-webui
   environment:
-    BEHAT_FILTER_TAGS: ~@skipOnEncryption&&~@skipOnEncryptionType:user-keys
+    BEHAT_FILTER_TAGS: "@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys"
     BROWSER: chrome
     DIVIDE_INTO_NUM_PARTS: 5
     MAILHOG_HOST: email
@@ -29698,7 +29698,7 @@ steps:
   - . /var/www/owncloud/saved-settings.sh
   - make test-acceptance-core-webui
   environment:
-    BEHAT_FILTER_TAGS: ~@skipOnEncryption&&~@skipOnEncryptionType:user-keys
+    BEHAT_FILTER_TAGS: "@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys"
     BROWSER: chrome
     DIVIDE_INTO_NUM_PARTS: 5
     MAILHOG_HOST: email
@@ -29921,7 +29921,7 @@ steps:
   - . /var/www/owncloud/saved-settings.sh
   - make test-acceptance-core-webui
   environment:
-    BEHAT_FILTER_TAGS: ~@skipOnEncryption&&~@skipOnEncryptionType:user-keys
+    BEHAT_FILTER_TAGS: "@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys"
     BROWSER: chrome
     DIVIDE_INTO_NUM_PARTS: 5
     MAILHOG_HOST: email
@@ -30144,7 +30144,7 @@ steps:
   - . /var/www/owncloud/saved-settings.sh
   - make test-acceptance-core-webui
   environment:
-    BEHAT_FILTER_TAGS: ~@skipOnEncryption&&~@skipOnEncryptionType:user-keys
+    BEHAT_FILTER_TAGS: "@smokeTest&&~@skipOnEncryption&&~@skipOnEncryptionType:user-keys"
     BROWSER: chrome
     DIVIDE_INTO_NUM_PARTS: 5
     MAILHOG_HOST: email


### PR DESCRIPTION
Part of issue #583 

The core webUI acceptance tests are run in the nightly job. With master-key encryption we run just the `smokeTest` scenarios. But accidentally we did not limit the scenarios for user-key encryption.

Make this consistent .

This will stop "extra" scenarios from being run, including various scenarios that are not expected to pass on LDAP anyway.