### PR TITLE
Facelift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
+.
 
 ## [0.15.2] - 2020-06-16
 

--- a/css/settings.css
+++ b/css/settings.css
@@ -47,10 +47,6 @@
 	height: auto;
 }
 
-#ldap .tablerow button.ui-multiselect {
-
-}
-
 #ldap .tablerow .inline > div {
 	display: inline-block;
 }
@@ -327,6 +323,7 @@ select[multiple=multiple] + button {
 @media all and (min-width: 768px) {
 	#ldap .ui-tabs .ui-tabs-nav li.stateIndicator {
 		display: block;
+	}
 }
 
 .ui-tabs .ui-tabs-panel {
@@ -357,8 +354,6 @@ select[multiple=multiple] + button {
     padding-right: 5px;
 	margin-top: 1em;
 }
-
-
 
 #ldap p {
 	margin-bottom: 1em;

--- a/css/settings.css
+++ b/css/settings.css
@@ -1,24 +1,88 @@
+#ldap section {
+	margin-bottom: 2rem;
+	width: 100% !important;
+}
+
+@media all and (min-width: 768px) {
+	#ldap section {
+		width: 60% !important;
+	}
+}
+
+#ldap section h3 {
+	border-bottom: 1px solid #efefef;
+	margin-left: -41px;
+	padding-left: 41px;
+	padding-bottom: 5px;
+}
+
 .table {
 	display: table;
 	width: 85%;
 }
 
 .tablerow {
-	display: table-row;
-	white-space: nowrap;
 	text-align: left;
-}
-
-.tablerow input, .tablerow textarea {
-	width: 100% !important;
-}
-
-.tablerow textarea {
-	height: 15px;
+	margin-bottom: 1rem;
 }
 
 #ldap .tablerow label {
-	margin-left: 3px;
+	margin-left: 0;
+	display: inline-block;
+}
+
+#ldap .tablerow input, 
+#ldap .tablerow textarea,
+#ldap .tablerow select,
+#ldap .tablerow button.ui-multiselect {
+	display: block;
+	width: calc(100% - 10px) !important;
+	padding: 10px 5px 10px 5px;
+	margin-bottom: .5rem;
+}
+
+#ldap .tablerow input, 
+#ldap .tablerow textarea,
+#ldap .tablerow select {
+	height: auto;
+}
+
+#ldap .tablerow button.ui-multiselect {
+
+}
+
+#ldap .tablerow .inline > div {
+	display: inline-block;
+}
+
+#ldap .tablerow .inline > div:first-of-type {
+	margin-right: 15px;
+}
+
+#ldap .tablerow .inline > div:first-of-type {
+	margin-right: 15px;
+	width: calc(66% - 8px) !important;
+}
+
+#ldap .tablerow .inline > div:last-of-type {
+	width: calc(33% - 5px) !important;
+}
+#ldap .tablerow .inline select {
+	width: 100% !important;
+}
+
+#ldap .tablerow input[type="checkbox"] {
+	width: 15px !important;
+	float: left;
+}
+
+#ldap .tablerow .hint {
+	clear: both;
+	font-size: .8em;
+}
+
+#ldap .tablerow .hint img {
+	height:1.75ex;
 }
 
 .ldapIconCopy {
@@ -33,12 +97,8 @@
 	display: none !important;
 }
 
-.ldapSettingsTabs {
-	float: right !important;
-}
 
 .ldapWizardControls {
-	width: 60%;
 	text-align: right;
 }
 
@@ -49,17 +109,6 @@
 	border-radius: 8px;
 	padding: 10px 8px 6px !important;
 	margin-bottom: 5px;
-}
-
-#ldapWizard1 .hostPortCombinator {
-	width: 60%;
-	display: table;
-}
-
-#ldapWizard1 .hostPortCombinatorSpan {
-	width: 14.5%;
-	display: inline-block;
-	text-align: right;
 }
 
 #ldapWizard1 .host {
@@ -159,16 +208,8 @@ span.ldapInputColElement {
 	margin-top: 9px;
 }
 
-#ldap fieldset p input[type=checkbox] {
-	vertical-align: bottom;
-}
-
-#ldap input[type=checkbox] {
-	width: 15px !important;
-}
-
 select[multiple=multiple] + button {
-	height: 28px;
+	height: 28px !important;
 	padding-top: 6px !important;
 	min-width: 40%;
 	max-width: 40%;
@@ -185,6 +226,18 @@ select[multiple=multiple] + button {
 }
 
 #ldap .ldap_saving img { height: 15px; }
+
+#ldap .app-name .ldap_config_state_indicator_container {
+	display: inline-block;
+	margin-left: 2em;
+}
+
+@media all and (min-width: 768px) {
+	#ldap .app-name .ldap_config_state_indicator_container {
+		display: none;
+	}
+}
+
 
 .ldap_config_state_indicator_sign {
 	display: inline-block;
@@ -209,20 +262,104 @@ select[multiple=multiple] + button {
 	left: -2000px;
 }
 
-#ldapSettings {
-	background-color: white;
+
+.ui-widget-header {
+	border: none;
+	border-bottom: 1px solid #efefef;
+	background: transparent;
+	color: #ffffff;
+}
+
+#ldap .header {
+	position: fixed;
+	background: #fff;
+	width: inherit;
+	top: 5.5em;
+	padding-top: 1.7em;
+	z-index: 1;
+}
+
+@media all and (min-width: 768px) {
+	#ldap .header {
+		top: 3.5em;
+	}
+}
+
+#ldap .ui-tabs {
+	background: transparent;
+	border: none;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li {
+	background: #efefef;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li.ui-state-active {
+	background: #fff;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li a {
+    padding: 0.7em 1.3em;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li.warn a {
+	padding-left: 3em;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li.warn a::before {
+	content: url("../img/exclamation-triangle-solid.svg");
+	height: 16px;
+	width: 16px;
+	transform: translate(0, 2px);
+	margin-right: .5em;
+	position: absolute;
+	left: 1.3em;
+}
+
+#ldap .ui-tabs .ui-tabs-nav li.stateIndicator {
+	color: #333333;
+	border: none;
+	background: transparent;
+	padding: 0.7em 1.3em;
+	display: none;
+}
+
+@media all and (min-width: 768px) {
+	#ldap .ui-tabs .ui-tabs-nav li.stateIndicator {
+		display: block;
+}
+
+.ui-tabs .ui-tabs-panel {
+	margin-top: 5.3em;
+}
+
+#ldap button {
+	padding: 11px 15px;
+	margin: 0 5px 10px 0;
+	width: auto;
+	height: auto;
+}
+
+#ldap button span {
 	padding: 0;
 }
 
-#ldapSettings > fieldset {
-	background-color: white;
+#ldap .resultscontainer {
+	display: inline-block;
 }
 
-#ldapSettings ul.ui-tabs-nav .ui-tabs-active,
-#ldapSettings ul.ui-tabs-nav .ui-tabs-active > a {
-	background-color: white;
+#ldap fieldset p label {
+    width: auto;
+    max-width: none;
+    display: block;
+    text-align: left;
+    padding-top: 0;
+    padding-right: 5px;
+	margin-top: 1em;
 }
 
-#ldapSettings div.ui-accordion-content {
-	background: white;
+
+
+#ldap p {
+	margin-bottom: 1em;
 }

--- a/img/exclamation-triangle-solid.svg
+++ b/img/exclamation-triangle-solid.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ebene_1" focusable="false" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+	 x="0px" y="0px" viewBox="0 0 576 512" style="enable-background:new 0 0 576 512;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#F0506E;}
+</style>
+<path class="st0" d="M569.5,440c18.5,32-4.7,72-41.6,72H48.1c-36.9,0-60-40.1-41.6-72L246.4,24c18.5-32,64.7-32,83.2,0L569.5,440
+	L569.5,440z M288,354c-25.4,0-46,20.6-46,46s20.6,46,46,46s46-20.6,46-46S313.4,354,288,354z M244.3,188.7l7.4,136
+	c0.3,6.4,5.6,11.3,12,11.3h48.5c6.4,0,11.6-5,12-11.3l7.4-136c0.4-6.9-5.1-12.7-12-12.7h-63.4C249.4,176,244,181.8,244.3,188.7
+	L244.3,188.7z"/>
+</svg>

--- a/js/wizard/view.js
+++ b/js/wizard/view.js
@@ -470,3 +470,10 @@ OCA = OCA || {};
 
 	OCA.LDAP.Wizard.WizardView = WizardView;
 })();
+
+$(document).ready(function () {
+	$('.ui-tabs .ui-tabs-panel').css('margin-top', $('#ldap .header').outerHeight())
+    $(window).on('resize', function(){
+		$('.ui-tabs .ui-tabs-panel').css('margin-top', $('#ldap .header').outerHeight())
+  	});
+});

--- a/js/wizard/view.js
+++ b/js/wizard/view.js
@@ -225,6 +225,12 @@ OCA = OCA || {};
 		 * @returns {boolean}
 		 */
 		onTabChange: function(event, ui) {
+			//check if it is hash link; else treat as regular link
+			if( $(ui.newTab).find('a').attr('href').indexOf('#') != 0 ){ 
+				window.open($(ui.newTab).find('a').attr('href'), '__blank');
+				return false
+			}
+
 			if(this.saveProcesses > 0) {
 				return false;
 			}

--- a/js/wizard/view.js
+++ b/js/wizard/view.js
@@ -356,7 +356,6 @@ OCA = OCA || {};
 		 * first config
 		 */
 		render: function () {
-			$('#ldapAdvancedAccordion').accordion({ heightStyle: 'content', animate: 'easeInOutCirc'});
 			this.$settings.tabs({});
 			$('#ldapSettings button:not(.icon-default-style):not(.ui-multiselect)').button();
 			$('#ldapSettings').tabs({ beforeActivate: this.onTabChange });

--- a/js/wizard/wizardTabElementary.js
+++ b/js/wizard/wizardTabElementary.js
@@ -289,7 +289,7 @@ OCA = OCA || {};
 						console.warn(payload.data.message);
 					}
 				}
-				OC.Notification.showTemporary(message);
+				$('#ldapTestBaseResult span').html(message)
 			}
 		},
 

--- a/templates/part.settingcontrols.php
+++ b/templates/part.settingcontrols.php
@@ -2,10 +2,4 @@
 	<button type="button" class="ldap_action_test_connection" name="ldap_action_test_connection">
 		<?php p($l->t('Test Configuration'));?>
 	</button>
-	<a href="<?php p(link_to_docs('admin-ldap')); ?>"
-		target="_blank" rel="noreferrer">
-		<img src="<?php print_unescaped(image_path('', 'actions/info.svg')); ?>"
-			style="height:1.75ex" />
-		<?php p($l->t('Help'));?>
-	</a>
 </div>

--- a/templates/part.wizard-loginfilter.php
+++ b/templates/part.wizard-loginfilter.php
@@ -1,61 +1,53 @@
 <fieldset id="ldapWizard3">
-	<div>
-		<p>
+	<section>
+		<div class="tablerow">
 			<?php p($l->t('When logging in, %s will find the user based on the following attributes:', $theme->getName()));?>
-		</p>
-		<p>
-			<label for="ldap_loginfilter_username">
-				<?php p($l->t('LDAP / AD Username:'));?>
-			</label>
-
-			<input type="checkbox" id="ldap_loginfilter_username"
-				   title="<?php p($l->t('Allows login against the LDAP / AD username, which is either uid or samaccountname and will be detected.'));?>"
-				   name="ldap_loginfilter_username" value="1" />
-		</p>
-		<p>
-			<label for="ldap_loginfilter_email">
-				<?php p($l->t('LDAP / AD Email Address:'));?>
-			</label>
-
-			<input type="checkbox" id="ldap_loginfilter_email"
-				   title="<?php p($l->t('Allows login against an email attribute. Mail and mailPrimaryAddress will be allowed. WARNING: Disabling login with email might require enabling strict login checking to be effective, please refer to ownCloud documentation for more details!'));?>"
-				   name="ldap_loginfilter_email" value="1" />
-		</p>
-		<p>
-			<label for="ldap_loginfilter_attributes">
-				<?php p($l->t('Other Attributes:'));?>
-			</label>
-
-			<select id="ldap_loginfilter_attributes" multiple="multiple"
-			 name="ldap_loginfilter_attributes" class="multiSelectPlugin">
-			</select>
-		</p>
-		<p>
+		</div>
+		<div class="tablerow">
+			<label for="ldap_loginfilter_username"><?php p($l->t('LDAP / AD Username:'));?></label>
+			<input type="checkbox" id="ldap_loginfilter_username" name="ldap_loginfilter_username" value="1" />
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Allows login against the LDAP / AD username, which is either uid or samaccountname and will be detected.'));?>"
+			</div>
+		</div>
+		<div class="tablerow">
+			<label for="ldap_loginfilter_email"><?php p($l->t('LDAP / AD Email Address:'));?></label>
+			<input type="checkbox" id="ldap_loginfilter_email" name="ldap_loginfilter_email" value="1" />
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Allows login against an email attribute. Mail and mailPrimaryAddress will be allowed. WARNING: Disabling login with email might require enabling strict login checking to be effective, please refer to ownCloud documentation for more details!'));?>
+			</div>
+			
+		</div>
+		<div class="tablerow">
+			<label for="ldap_loginfilter_attributes"><?php p($l->t('Other Attributes:'));?></label>
+			<select id="ldap_loginfilter_attributes" multiple="multiple" name="ldap_loginfilter_attributes" class="multiSelectPlugin"></select>
+		</div>
+		<div class="tablerow">
 			<label><a id='toggleRawLoginFilter' class='ldapToggle'>↓ <?php p($l->t('Edit LDAP Query'));?></a></label>
-		</p>
-		<p id="ldapReadOnlyLoginFilterContainer" class="hidden ldapReadOnlyFilterContainer">
+		</div>
+		<div id="ldapReadOnlyLoginFilterContainer" class="hidden ldapReadOnlyFilterContainer tablerow">
 			<label><?php p($l->t('LDAP Filter:'));?></label>
 			<span class="ldapFilterReadOnlyElement ldapInputColElement"></span>
-		</p>
-		<p id="rawLoginFilterContainer" class="invisible">
-			<textarea type="text" id="ldap_login_filter" name="ldap_login_filter"
-				class="ldapFilterInputElement"
-				placeholder="<?php p($l->t('Edit LDAP Query'));?>"
-				title="<?php p($l->t('Defines the filter to apply, when login is attempted. %%uid replaces the username in the login action. Example: "uid=%%uid"'));?>">
-			</textarea>
-		</p>
-		<p>
+		</div>
+		<div id="rawLoginFilterContainer" class="tablerow invisible">
+			<label><?php p($l->t('Edit LDAP Query'));?></label>
+			<textarea type="text" id="ldap_login_filter" name="ldap_login_filter" class="ldapFilterInputElement"></textarea>
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Defines the filter to apply, when login is attempted. %%uid replaces the username in the login action. Example: "uid=%%uid"'));?>
+			</div>
+		</div>
+		<div class="tablerow">
 			<div class="ldapWizardInfo invisible">&nbsp;</div>
-		</p>
-		<p class="ldap_verify">
-			<input type="text" id="ldap_test_loginname" name="ldap_test_loginname"
-				   placeholder="<?php p($l->t('Test Loginname'));?>"
-				   class="ldapVerifyInput"
-				   title="Attempts to receive a DN for the given loginname and the current login filter"/>
-			<button class="ldapVerifyLoginName" name="ldapTestLoginSettings" type="button" disabled="disabled">
-				<?php p($l->t('Verify settings'));?>
-			</button>
-		</p>
+		</div>
+		<div class="tablerow ldap_verify">
+			<label><?php p($l->t('Test Loginname'));?></label>
+			<input type="text" id="ldap_test_loginname" name="ldap_test_loginname" class="ldapVerifyInput" />
+			
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> Attempts to receive a DN for the given loginname and the current login filter
+			</div>
+			<button class="ldapVerifyLoginName" name="ldapTestLoginSettings" disabled="disabled"><?php p($l->t('Verify settings'));?></button>
+		</div>
 		<?php print_unescaped($_['wizardControls']); ?>
-	</div>
+	</section>
 </fieldset>

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -10,21 +10,21 @@
 			<div class="inline">
 				<div>
 					<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-					<?php if (0 === \count($_['serverConfigurationPrefixes'])) {
-    ?>
+					<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
+	?>
 						<option value="" selected><?php p($l->t('1. Server')); ?></option>');
 					<?php
 } else {
-        $i = 1;
-        $sel = ' selected';
-        foreach ($_['serverConfigurationPrefixes'] as $prefix) {
-            ?>
+		$i = 1;
+		$sel = ' selected';
+		foreach ($_['serverConfigurationPrefixes'] as $prefix) {
+			?>
 								<option value="<?php p($prefix); ?>"<?php p($sel);
-            $sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
+			$sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
 							<?php
-        }
-    }
-                    ?>
+		}
+	}
+					?>
 					</select>
 				</div>
 

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -10,18 +10,20 @@
 			<div class="inline">
 				<div>
 					<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-					<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
+					<?php if (\count($_['serverConfigurationPrefixes']) === 0)
+					{
 					?>
 						<option value="" selected><?php p($l->t('1. Server')); ?></option>');
 					<?php
 					} else {
 						$i = 1;
 						$sel = ' selected';
-						foreach ($_['serverConfigurationPrefixes'] as $prefix) {
+						foreach ($_['serverConfigurationPrefixes'] as $prefix)
+						{
 							?>
 								<option value="<?php p($prefix); ?>"<?php p($sel);
 							$sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
-								<?php
+							<?php
 						}
 					}
 					?>

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -4,104 +4,118 @@
 	<input type="password" id="fake_password" name="fake_password"
 				autocomplete="off" />
 </div>
-
 <fieldset id="ldapWizard1">
-		<p>
-		<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-		<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
-	?>
-				<option value="" selected><?php p($l->t('1. Server')); ?></option>');
-			<?php
-} else {
-		$i = 1;
-		$sel = ' selected';
-		foreach ($_['serverConfigurationPrefixes'] as $prefix) {
-			?>
-				<option value="<?php p($prefix); ?>"<?php p($sel);
-			$sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
-				<?php
-		}
-	}
-		?>
-		</select>
-		<button type="button" id="ldap_action_add_configuration"
-			name="ldap_action_add_configuration" class="icon-add icon-default-style"
-			title="<?php p($l->t('Add a new and blank configuration'));?>">&nbsp;</button>
-		<button type="button" id="ldap_action_copy_configuration"
-			name="ldap_action_copy_configuration"
-			class="ldapIconCopy icon-default-style"
-			title="<?php p($l->t('Copy current configuration into new directory binding'));?>">&nbsp;</button>
-		<button type="button" id="ldap_action_delete_configuration"
-			name="ldap_action_delete_configuration" class="icon-delete icon-default-style"
-			title="<?php p($l->t('Delete the current configuration'));?>">&nbsp;</button>
-		</p>
-
-		<div class="hostPortCombinator">
-			<div class="tablerow">
-				<div class="tablecell">
-					<div class="table">
-						<input type="text" class="host" id="ldap_host"
-							name="ldap_host"
-							placeholder="<?php p($l->t('Host'));?>"
-							title="<?php p($l->t('You can omit the protocol, except you require SSL. Then start with ldaps://'));?>"
-							/>
-						<span class="hostPortCombinatorSpan">
-							<input type="number" id="ldap_port" name="ldap_port"
-								placeholder="<?php p($l->t('Port'));?>" />
-						</span>
-					</div>
+	<section>
+		<div class="tablerow">
+			<div class="inline">
+				<div>
+					<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
+					<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
+					?>
+						<option value="" selected><?php p($l->t('1. Server')); ?></option>');
+					<?php
+					} else {
+						$i = 1;
+						$sel = ' selected';
+						foreach ($_['serverConfigurationPrefixes'] as $prefix) {
+							?>
+								<option value="<?php p($prefix); ?>"<?php p($sel);
+							$sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
+								<?php
+						}
+					}
+					?>
+					</select>
 				</div>
-			</div>
 
-			<div class="tablerow">
-				<input type="checkbox" id="ldap_tls" name="ldap_tls" title="<?php p($l->t('Enable StartTLS support (also known as LDAP over TLS) for the connection.  Note that this is different than LDAPS (LDAP over SSL) which doesn\'t need this checkbox checked. You\'ll need to import the LDAP server\'s certificate in your %s server.', $theme->getName()));?>" value="1">
-				<label for="ldap_tls"><?php p($l->t('Use StartTLS support'));?></label>
-			</div>
-
-			<div class="tablerow">
-				<input type="text" id="ldap_dn" name="ldap_dn"
-				class="tablecell"
-				placeholder="<?php p($l->t('User DN'));?>" autocomplete="off"
-				title="<?php p($l->t('The DN of the client user with which the bind shall be done, e.g. uid=agent,dc=example,dc=com. For anonymous access, leave DN and Password empty.'));?>"
-				/>
-			</div>
-
-			<div class="tablerow">
-				<input type="password" id="ldap_agent_password"
-				class="tablecell" name="ldap_agent_password"
-				placeholder="<?php p($l->t('Password'));?>" autocomplete="off"
-				title="<?php p($l->t('For anonymous access, leave DN and Password empty.'));?>"
-				/>
-			</div>
-
-			<div class="tablerow">
-				<textarea id="ldap_base" name="ldap_base"
-					class="tablecell"
-					placeholder="<?php p($l->t('One Base DN per line'));?>"
-					title="<?php p($l->t('You can specify Base DN for users and groups in the Advanced tab'));?>">
-				</textarea>
-				<button class="ldapDetectBase" name="ldapDetectBase" type="button">
-					<?php p($l->t('Detect Base DN'));?>
-				</button>
-				<button class="ldapTestBase" name="ldapTestBase" type="button">
-					<?php p($l->t('Test Base DN'));?>
-				</button>
-			</div>
-
-			<div class="tablerow left">
-				<input type="checkbox" id="ldap_experienced_admin" value="1"
-					name="ldap_experienced_admin" class="tablecell"
-					title="<?php p($l->t('Avoids automatic LDAP requests. Better for bigger setups, but requires some LDAP knowledge.'));?>"
-					/>
-				<label for="ldap_experienced_admin" class="tablecell">
-					<?php p($l->t('Manually enter LDAP filters (recommended for large directories)'));?>
-				</label>
-			</div>
-
-			<div class="tablerow">
-				<div class="tablecell ldapWizardInfo invisible">&nbsp;
+				<div>
+					<button type="button" id="ldap_action_add_configuration"
+						name="ldap_action_add_configuration" class="icon-add icon-default-style"
+						title="<?php p($l->t('Add a new and blank configuration'));?>">&nbsp;</button>
+					<button type="button" id="ldap_action_copy_configuration"
+						name="ldap_action_copy_configuration"
+						class="ldapIconCopy icon-default-style"
+						title="<?php p($l->t('Copy current configuration into new directory binding'));?>">&nbsp;</button>
+					<button type="button" id="ldap_action_delete_configuration"
+					name="ldap_action_delete_configuration" class="icon-delete icon-default-style"
+					title="<?php p($l->t('Delete the current configuration'));?>">&nbsp;</button>
 				</div>
 			</div>
 		</div>
+
+		<div class="tablerow">
+			<div class="inline">
+				<div>
+					<label><?php p($l->t('Host'));?></label>
+					<input type="text" class="host" id="ldap_host" name="ldap_host" />
+				</div>
+
+				<div>
+					<label><?php p($l->t('Port'));?></label>
+					<input type="number" id="ldap_port" name="ldap_port" />
+				</div>
+			</div>
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can omit the protocol, except you require SSL. Then start with ldaps://'));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
+			<label for="ldap_tls"><?php p($l->t('Use StartTLS support'));?></label>
+			<input type="checkbox" id="ldap_tls" name="ldap_tls" value="1">
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Enable StartTLS support (also known as LDAP over TLS) for the connection.  Note that this is different than LDAPS (LDAP over SSL) which doesn\'t need this checkbox checked. You\'ll need to import the LDAP server\'s certificate in your %s server.', $theme->getName()));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
+			<label><?php p($l->t('User DN'));?></label>
+			<input type="text" id="ldap_dn" name="ldap_dn" class="tablecell" autocomplete="off" />
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('The DN of the client user with which the bind shall be done, e.g. uid=agent,dc=example,dc=com. For anonymous access, leave DN and Password empty.'));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
+			<label><?php p($l->t('Password'));?></label>
+			<input type="password" id="ldap_agent_password" class="tablecell" name="ldap_agent_password" autocomplete="off" />
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('For anonymous access, leave DN and Password empty.'));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
+			<label><?php p($l->t('One Base DN per line'));?></label>
+			<textarea id="ldap_base" name="ldap_base" class="tablecell" placeholder="" >
+			</textarea>
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can specify Base DN for users and groups in the Advanced tab'));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
+			<button class="ldapDetectBase" name="ldapDetectBase" type="button"><?php p($l->t('Detect Base DN'));?></button>
+			<button class="ldapTestBase" name="ldapTestBase" type="button"><?php p($l->t('Test Base DN'));?></button>
+			<div class="resultscontainer" id="ldapTestBaseResult"><span></span></div>
+		</div>
+
+		<div class="tablerow">
+			<label for="ldap_experienced_admin" class="tablecell">
+				<?php p($l->t('Manually enter LDAP filters (recommended for large directories)'));?>
+			</label>
+			<input type="checkbox" id="ldap_experienced_admin" value="1" name="ldap_experienced_admin" class="tablecell" />
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Avoids automatic LDAP requests. Better for bigger setups, but requires some LDAP knowledge.'));?>
+			</div>
+		</div>
+	</section>
+
+	<section>
 		<?php print_unescaped($_['wizardControls']); ?>
-	</fieldset>
+
+		<div class="tablerow">
+			<div class="tablecell ldapWizardInfo invisible">&nbsp;
+			</div>
+		</div>
+	</section>
+</fieldset>

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -10,7 +10,7 @@
 			<div class="inline">
 				<div>
 					<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-					<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
+					<?php if (0 === \count($_['serverConfigurationPrefixes'])) {
     ?>
 						<option value="" selected><?php p($l->t('1. Server')); ?></option>');
 					<?php
@@ -31,14 +31,14 @@
 				<div>
 					<button type="button" id="ldap_action_add_configuration"
 						name="ldap_action_add_configuration" class="icon-add icon-default-style"
-						title="<?php p($l->t('Add a new and blank configuration'));?>">&nbsp;</button>
+						title="<?php p($l->t('Add a new and blank configuration')); ?>">&nbsp;</button>
 					<button type="button" id="ldap_action_copy_configuration"
 						name="ldap_action_copy_configuration"
 						class="ldapIconCopy icon-default-style"
-						title="<?php p($l->t('Copy current configuration into new directory binding'));?>">&nbsp;</button>
+						title="<?php p($l->t('Copy current configuration into new directory binding')); ?>">&nbsp;</button>
 					<button type="button" id="ldap_action_delete_configuration"
 					name="ldap_action_delete_configuration" class="icon-delete icon-default-style"
-					title="<?php p($l->t('Delete the current configuration'));?>">&nbsp;</button>
+					title="<?php p($l->t('Delete the current configuration')); ?>">&nbsp;</button>
 				</div>
 			</div>
 		</div>
@@ -46,66 +46,66 @@
 		<div class="tablerow">
 			<div class="inline">
 				<div>
-					<label><?php p($l->t('Host'));?></label>
+					<label><?php p($l->t('Host')); ?></label>
 					<input type="text" class="host" id="ldap_host" name="ldap_host" />
 				</div>
 
 				<div>
-					<label><?php p($l->t('Port'));?></label>
+					<label><?php p($l->t('Port')); ?></label>
 					<input type="number" id="ldap_port" name="ldap_port" />
 				</div>
 			</div>
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can omit the protocol, except you require SSL. Then start with ldaps://'));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can omit the protocol, except you require SSL. Then start with ldaps://')); ?>
 			</div>
 		</div>
 
 		<div class="tablerow">
-			<label for="ldap_tls"><?php p($l->t('Use StartTLS support'));?></label>
+			<label for="ldap_tls"><?php p($l->t('Use StartTLS support')); ?></label>
 			<input type="checkbox" id="ldap_tls" name="ldap_tls" value="1">
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Enable StartTLS support (also known as LDAP over TLS) for the connection.  Note that this is different than LDAPS (LDAP over SSL) which doesn\'t need this checkbox checked. You\'ll need to import the LDAP server\'s certificate in your %s server.', $theme->getName()));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Enable StartTLS support (also known as LDAP over TLS) for the connection.  Note that this is different than LDAPS (LDAP over SSL) which doesn\'t need this checkbox checked. You\'ll need to import the LDAP server\'s certificate in your %s server.', $theme->getName())); ?>
 			</div>
 		</div>
 
 		<div class="tablerow">
-			<label><?php p($l->t('User DN'));?></label>
+			<label><?php p($l->t('User DN')); ?></label>
 			<input type="text" id="ldap_dn" name="ldap_dn" class="tablecell" autocomplete="off" />
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('The DN of the client user with which the bind shall be done, e.g. uid=agent,dc=example,dc=com. For anonymous access, leave DN and Password empty.'));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('The DN of the client user with which the bind shall be done, e.g. uid=agent,dc=example,dc=com. For anonymous access, leave DN and Password empty.')); ?>
 			</div>
 		</div>
 
 		<div class="tablerow">
-			<label><?php p($l->t('Password'));?></label>
+			<label><?php p($l->t('Password')); ?></label>
 			<input type="password" id="ldap_agent_password" class="tablecell" name="ldap_agent_password" autocomplete="off" />
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('For anonymous access, leave DN and Password empty.'));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('For anonymous access, leave DN and Password empty.')); ?>
 			</div>
 		</div>
 
 		<div class="tablerow">
-			<label><?php p($l->t('One Base DN per line'));?></label>
+			<label><?php p($l->t('One Base DN per line')); ?></label>
 			<textarea id="ldap_base" name="ldap_base" class="tablecell" placeholder="" >
 			</textarea>
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can specify Base DN for users and groups in the Advanced tab'));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('You can specify Base DN for users and groups in the Advanced tab')); ?>
 			</div>
 		</div>
 
 		<div class="tablerow">
-			<button class="ldapDetectBase" name="ldapDetectBase" type="button"><?php p($l->t('Detect Base DN'));?></button>
-			<button class="ldapTestBase" name="ldapTestBase" type="button"><?php p($l->t('Test Base DN'));?></button>
+			<button class="ldapDetectBase" name="ldapDetectBase" type="button"><?php p($l->t('Detect Base DN')); ?></button>
+			<button class="ldapTestBase" name="ldapTestBase" type="button"><?php p($l->t('Test Base DN')); ?></button>
 			<div class="resultscontainer" id="ldapTestBaseResult"><span></span></div>
 		</div>
 
 		<div class="tablerow">
 			<label for="ldap_experienced_admin" class="tablecell">
-				<?php p($l->t('Manually enter LDAP filters (recommended for large directories)'));?>
+				<?php p($l->t('Manually enter LDAP filters (recommended for large directories)')); ?>
 			</label>
 			<input type="checkbox" id="ldap_experienced_admin" value="1" name="ldap_experienced_admin" class="tablecell" />
 			<div class="hint">
-				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Avoids automatic LDAP requests. Better for bigger setups, but requires some LDAP knowledge.'));?>
+				<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Avoids automatic LDAP requests. Better for bigger setups, but requires some LDAP knowledge.')); ?>
 			</div>
 		</div>
 	</section>

--- a/templates/part.wizard-server.php
+++ b/templates/part.wizard-server.php
@@ -10,23 +10,21 @@
 			<div class="inline">
 				<div>
 					<select id="ldap_serverconfig_chooser" name="ldap_serverconfig_chooser">
-					<?php if (\count($_['serverConfigurationPrefixes']) === 0)
-					{
-					?>
+					<?php if (\count($_['serverConfigurationPrefixes']) === 0) {
+    ?>
 						<option value="" selected><?php p($l->t('1. Server')); ?></option>');
 					<?php
-					} else {
-						$i = 1;
-						$sel = ' selected';
-						foreach ($_['serverConfigurationPrefixes'] as $prefix)
-						{
-							?>
+} else {
+        $i = 1;
+        $sel = ' selected';
+        foreach ($_['serverConfigurationPrefixes'] as $prefix) {
+            ?>
 								<option value="<?php p($prefix); ?>"<?php p($sel);
-							$sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
+            $sel = ''; ?>><?php p($l->t('%s. Server:', [$i++])); ?> <?php p(' '.$_['serverConfigurationHosts'][$prefix]); ?></option>
 							<?php
-						}
-					}
-					?>
+        }
+    }
+                    ?>
 					</select>
 				</div>
 

--- a/templates/part.wizard-userfilter.php
+++ b/templates/part.wizard-userfilter.php
@@ -1,66 +1,64 @@
 <fieldset id="ldapWizard2">
-	<div>
-		<p>
+	<section>
+		<div class="tablerow">
 			<?php p($l->t('%s access is limited to users meeting these criteria:', $theme->getName()));?>
-		</p>
-		<p>
-			<label for="ldap_userfilter_objectclass">
-				<?php p($l->t('Only these object classes:'));?>
-			</label>
-
-			<select id="ldap_userfilter_objectclass" multiple="multiple"
-			 name="ldap_userfilter_objectclass" class="multiSelectPlugin">
-			</select>
-		</p>
-		<p>
-			<label></label>
-			<span class="ldapInputColElement"><?php p($l->t('The most common object classes for users are organizationalPerson, person, user, and inetOrgPerson. If you are not sure which object class to select, please consult your directory admin.'));?></span>
-		</p>
-		<p>
+		</div>
+		<div class="tablerow">
+			<label for="ldap_userfilter_objectclass"><?php p($l->t('Only these object classes:'));?></label>
+			<select id="ldap_userfilter_objectclass" multiple="multiple" name="ldap_userfilter_objectclass" class="multiSelectPlugin"></select>
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" > <?php p($l->t('The most common object classes for users are organizationalPerson, person, user, and inetOrgPerson. If you are not sure which object class to select, please consult your directory admin.'));?>
+			</div>
+		</div>
+		
+		<div class="tablerow">
 			<label for="ldap_userfilter_groups">
 				<?php p($l->t('Only from these groups:'));?>
 			</label>
 
 			<input type="text" class="ldapManyGroupsSupport ldapManyGroupsSearch hidden" placeholder="<?php p($l->t('Search groups'));?>" />
 
-			<select id="ldap_userfilter_groups" multiple="multiple"
-			 name="ldap_userfilter_groups" class="multiSelectPlugin">
-			</select>
-		</p>
-		<p class="ldapManyGroupsSupport hidden">
-			<label></label>
-			<select class="ldapGroupList ldapGroupListAvailable" multiple="multiple"
-					title="<?php p($l->t('Available groups'));?>"></select>
+			<select id="ldap_userfilter_groups" multiple="multiple" name="ldap_userfilter_groups" class="multiSelectPlugin"></select>
+		</div>
+
+		<div class="tablerow ldapManyGroupsSupport hidden">
+			<label><?php p($l->t('Available groups'));?></label>
+			<select class="ldapGroupList ldapGroupListAvailable" multiple="multiple"></select>
 			<span class="buttonSpan">
-				<button class="ldapGroupListSelect" type="button">&gt;</button><br/>
+				<button class="ldapGroupListSelect" type="button">&gt;</button>
 				<button class="ldapGroupListDeselect" type="button">&lt;</button>
 			</span>
-			<select class="ldapGroupList ldapGroupListSelected" multiple="multiple"
-					title="<?php p($l->t('Selected groups'));?>"></select>
-		</p>
-		<p>
+			<label><?php p($l->t('Selected groups'));?></label>
+			<select class="ldapGroupList ldapGroupListSelected" multiple="multiple"></select>
+		</div>
+
+		<div class="tablerow">
 			<label><a id='toggleRawUserFilter' class='ldapToggle'>↓ <?php p($l->t('Edit LDAP Query'));?></a></label>
-		</p>
-		<p id="ldapReadOnlyUserFilterContainer" class="hidden ldapReadOnlyFilterContainer">
+		</div>
+
+		<div id="ldapReadOnlyUserFilterContainer" class="tablerow hidden ldapReadOnlyFilterContainer">
 			<label><?php p($l->t('LDAP Filter:'));?></label>
-			<span class="ldapFilterReadOnlyElement ldapInputColElement"></span>
-		</p>
-		<p id="rawUserFilterContainer">
-			<textarea type="text" id="ldap_userlist_filter" name="ldap_userlist_filter"
-				class="ldapFilterInputElement"
-				placeholder="<?php p($l->t('Edit LDAP Query'));?>"
-				title="<?php p($l->t('The filter specifies which LDAP users shall have access to the %s instance.', $theme->getName()));?>">
-			</textarea>
-		</p>
-		<p>
+			<div class="ldapFilterReadOnlyElement"></div>
+		</div>
+
+		<div class="tablerow" id="rawUserFilterContainer">
+			<label><?php p($l->t('Edit LDAP Query'));?></label>
+			<textarea type="text" id="ldap_userlist_filter" name="ldap_userlist_filter" class="ldapFilterInputElement"></textarea>
+			<div class="hint">
+				<img src="/core/img/actions/info.svg" > <?php p($l->t('The filter specifies which LDAP users shall have access to the %s instance.', $theme->getName()));?>
+			</div>
+		</div>
+
+		<div class="tablerow">
 			<div class="ldapWizardInfo invisible">&nbsp;</div>
-		</p>
-		<p class="ldap_count">
+		</div>
+
+		<div class="ldap_count tablerow">
 			<button class="ldapGetEntryCount ldapGetUserCount" name="ldapGetEntryCount" type="button">
 				<?php p($l->t('Verify settings and count users'));?>
 			</button>
 			<span id="ldap_user_count"></span>
-		</p>
+		</div>
 		<?php print_unescaped($_['wizardControls']); ?>
-	</div>
+	</section>
 </fieldset>

--- a/templates/part.wizardcontrols.php
+++ b/templates/part.wizardcontrols.php
@@ -1,17 +1,5 @@
 <div class="ldapWizardControls">
 	<span class="ldap_saving hidden"><?php p($l->t('Saving'));?> <img class="wizSpinner" src="<?php p(image_path('core', 'loading.gif')); ?>"/></span>
-	<span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span>
-	<button class="ldap_action_back invisible" name="ldap_action_back"
-			type="button">
-		<?php p($l->t('Back'));?>
-	</button>
-	<button class="ldap_action_continue" name="ldap_action_continue" type="button">
-		<?php p($l->t('Continue'));?>
-	</button>
-	<a href="<?php p(link_to_docs('admin-ldap')); ?>"
-		target="_blank" rel="noreferrer">
-		<img src="<?php print_unescaped(image_path('', 'actions/info.svg')); ?>"
-			style="height:1.75ex" />
-		<span class="ldap_grey"><?php p($l->t('Help'));?></span>
-	</a>
+	<button class="ldap_action_back invisible" name="ldap_action_back"><?php p($l->t('Back'));?></button>
+	<button class="ldap_action_continue" name="ldap_action_continue"><?php p($l->t('Continue'));?></button>
 </div>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -50,81 +50,234 @@ style('user_ldap', 'settings');
 ?>
 
 <form id="ldap" class="section" action="#" method="post">
-	<h2 class="app-name"><?php p($l->t('LDAP')); ?></h2>
-
-	<div id="ldapSettings">
-	<ul>
-		<?php foreach ($_['toc'] as $id => $title) {
-	?>
-			<li id="<?php p($id); ?>"><a href="<?php p($id); ?>"><?php p($title); ?></a></li>
-		<?php
-} ?>
-		<li class="ldapSettingsTabs"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
-		<li class="ldapSettingsTabs"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
-	</ul>
-		<?php if (OCP\App::isEnabled('user_webdavauth')) {
-		print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
-	}
-		if (!\function_exists('ldap_connect')) {
-			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
-		}
-		?>
+		<div id="ldapSettings">
+			<div class="header">
+			<h2 class="app-name"><?php p($l->t('LDAP')); ?><div class="ldap_config_state_indicator_container"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></div></h2>
+			<ul>
+				<?php foreach ($_['toc'] as $id => $title) {?>
+					<li id="<?php p($id); ?>"><a href="<?php p($id); ?>"><?php p($title); ?></a></li>
+				<?php
+				} ?>
+				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
+				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
+				<li class="stateIndicator"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></li>
+				<li>
+					<div>
+					<a href="<?php p(link_to_docs('admin-ldap')); ?>" target="_blank" rel="noreferrer">
+						<img src="<?php print_unescaped(image_path('', 'actions/info.svg')); ?>" style="height:1.75ex" />
+						<span class="ldap_grey"><?php p($l->t('Help'));?></span>
+					</a>
+					<div>
+				</li>
+			</ul>
+			</div>
+			<?php if (OCP\App::isEnabled('user_webdavauth')) {
+				print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
+			}
+			if (!\function_exists('ldap_connect')) {
+				print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
+			}
+			?>
 	<?php print_unescaped($_['tabs']); ?>
 	<fieldset id="ldapSettings-1">
 		<div id="ldapAdvancedAccordion">
-			<h3><?php p($l->t('Connection Settings'));?></h3>
-			<div>
-				<p><label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label><input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" /></p>
-				<p><label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label><input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>" title="<?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>"></p>
-				<p><label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port'));?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  /></p>
-				<p><label for="ldap_override_main_server"><?php p($l->t('Disable Main Server'));?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"  title="<?php p($l->t('Only connect to the replica server.'));?>" /></p>
-				<p><label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.'));?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" title="<?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName()));?>" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1"><br/></p>
-				<p><label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live'));?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" title="<?php p($l->t('in seconds. A change empties the cache.'));?>" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" /></p>
-				<p><label for="ldap_network_timeout"><?php p($l->t('Network Timeout'));?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" title="<?php p($l->t('timeout for all the ldap network operations, in seconds.'));?>" data-default="<?php p($_['ldap_network_timeout_default']); ?>" /></p>
-			</div>
-			<h3><?php p($l->t('Directory Settings'));?></h3>
-			<div>
-				<p><label for="ldap_display_name"><?php p($l->t('User Display Name Field'));?></label><input type="text" id="ldap_display_name" name="ldap_display_name" data-default="<?php p($_['ldap_display_name_default']); ?>" title="<?php p($l->t('The LDAP attribute to use to generate the user\'s display name.'));?>" /></p>
-				<p><label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field'));?></label><input type="text" id="ldap_user_display_name_2" name="ldap_user_display_name_2" data-default="<?php p($_['ldap_user_display_name_2_default']); ?>" title="<?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.'));?>" /></p>
-				<p><label for="ldap_base_users"><?php p($l->t('Base User Tree'));?></label><textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line'));?>" data-default="<?php p($_['ldap_base_users_default']); ?>" title="<?php p($l->t('Base User Tree'));?>"></textarea></p>
-				<p><label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes'));?></label><textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>" title="<?php p($l->t('User Search Attributes'));?>"></textarea></p>
-				<p><label></label><small><?php p($l->t('Each attribute value is truncated to 191 characters'));?></small></p>
-				<p><label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field'));?></label><input type="text" id="ldap_group_display_name" name="ldap_group_display_name" data-default="<?php p($_['ldap_group_display_name_default']); ?>" title="<?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.'));?>" /></p>
-				<p><label for="ldap_base_groups"><?php p($l->t('Base Group Tree'));?></label><textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line'));?>" data-default="<?php p($_['ldap_base_groups_default']); ?>" title="<?php p($l->t('Base Group Tree'));?>"></textarea></p>
-				<p><label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes'));?></label><textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>" title="<?php p($l->t('Group Search Attributes'));?>"></textarea></p>
-				<p><label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label><select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" ><option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {
-			p(' selected');
-		} ?>>uniqueMember</option><option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {
-			p(' selected');
-		} ?>>memberUid</option><option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {
-			p(' selected');
-		} ?>>member (AD)</option></select></p>
-				<p><label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL'));?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" title="<?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)'));?>" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" /></p>
-				<p><label for="ldap_nested_groups"><?php p($l->t('Nested Groups'));?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>"  title="<?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)'));?>" /></p>
-				<p><label for="ldap_paging_size"><?php p($l->t('Paging chunksize'));?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" title="<?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)'));?>" data-default="<?php p($_['ldap_paging_size_default']); ?>" /></p>
-			</div>
-			<h3><?php p($l->t('Special Attributes'));?></h3>
-			<div>
-				<p><label for="ldap_quota_attr"><?php p($l->t('Quota Field'));?></label><input type="text" id="ldap_quota_attr" name="ldap_quota_attr" data-default="<?php p($_['ldap_quota_attr_default']); ?>" title="<?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.'));?>" /></p>
-				<p><label for="ldap_quota_def"><?php p($l->t('Quota Default'));?></label><input type="text" id="ldap_quota_def" name="ldap_quota_def" data-default="<?php p($_['ldap_quota_def_default']); ?>" title="<?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.'));?>" /></p>
-				<p><label for="ldap_email_attr"><?php p($l->t('Email Field'));?></label><input type="text" id="ldap_email_attr" name="ldap_email_attr" data-default="<?php p($_['ldap_email_attr_default']); ?>" title="<?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.'));?>" /></p>
-				<p><label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule'));?></label><input type="text" id="home_folder_naming_rule" name="home_folder_naming_rule" title="<?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.'));?>" data-default="<?php p($_['home_folder_naming_rule_default']); ?>" /></p>
-			</div>
+			<section>
+				<h3><?php p($l->t('Connection Settings'));?></h3>
+				<div>
+					<div class="tablerow">
+						<input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" />
+						<label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label>
+					</div>
+
+					<div class="tablerow">
+						<label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label>
+						<input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>">
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port'));?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  />
+					</div>
+					<div class="tablerow">
+						<label for="ldap_override_main_server"><?php p($l->t('Disable Main Server'));?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"/>
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Only connect to the replica server.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.'));?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1">
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName()));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live'));?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('in seconds. A change empties the cache.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_network_timeout"><?php p($l->t('Network Timeout'));?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" data-default="<?php p($_['ldap_network_timeout_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('timeout for all the ldap network operations, in seconds.'));?>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section>
+				<h3><?php p($l->t('Directory Settings'));?></h3>
+				<div>
+					<div class="tablerow">
+						<label for="ldap_display_name"><?php p($l->t('User Display Name Field'));?></label>
+						<input type="text" id="ldap_display_name" name="ldap_display_name" data-default="<?php p($_['ldap_display_name_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the user\'s display name.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field'));?></label>
+						<input type="text" id="ldap_user_display_name_2" name="ldap_user_display_name_2" data-default="<?php p($_['ldap_user_display_name_2_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_base_users"><?php p($l->t('Base User Tree'));?></label>
+						<textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line'));?>" data-default="<?php p($_['ldap_base_users_default']); ?>"></textarea>
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Base User Tree'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes'));?></label>
+						<textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>"></textarea>
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('User Search Attributes'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label></label>
+						<small><?php p($l->t('Each attribute value is truncated to 191 characters'));?></small>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field'));?></label>
+						<input type="text" id="ldap_group_display_name" name="ldap_group_display_name" data-default="<?php p($_['ldap_group_display_name_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_base_groups"><?php p($l->t('Base Group Tree'));?></label>
+						<textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line'));?>" data-default="<?php p($_['ldap_base_groups_default']); ?>"></textarea>
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Base Group Tree'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes'));?></label>
+						<textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>"></textarea>
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Group Search Attributes'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+                        <label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label>
+                        <select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
+                            <option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {p(' selected'); } ?>>uniqueMember</option>
+                            <option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {p(' selected');} ?>>memberUid</option>
+                            <option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {p(' selected');} ?>>member (AD)</option>
+                        </select>
+                    </div>
+					<div class="tablerow">
+						<label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL'));?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_nested_groups"><?php p($l->t('Nested Groups'));?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)'));?>
+						</div>
+					</div>
+                    <div class="tablerow">
+						<label for="ldap_paging_size"><?php p($l->t('Paging chunksize'));?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" data-default="<?php p($_['ldap_paging_size_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)'));?>
+						</div>
+					</div>
+				</div>
+			</section>
+
+			<section>
+				<h3><?php p($l->t('Special Attributes'));?></h3>
+				<div>
+					<div class="tablerow">
+						<label for="ldap_quota_attr"><?php p($l->t('Quota Field'));?></label>
+						<input type="text" id="ldap_quota_attr" name="ldap_quota_attr" data-default="<?php p($_['ldap_quota_attr_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_quota_def"><?php p($l->t('Quota Default'));?></label>
+						<input type="text" id="ldap_quota_def" name="ldap_quota_def" data-default="<?php p($_['ldap_quota_def_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="ldap_email_attr"><?php p($l->t('Email Field'));?></label>
+						<input type="text" id="ldap_email_attr" name="ldap_email_attr" data-default="<?php p($_['ldap_email_attr_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.'));?>
+						</div>
+					</div>
+					<div class="tablerow">
+						<label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule'));?></label>
+						<input type="text" id="home_folder_naming_rule" name="home_folder_naming_rule" data-default="<?php p($_['home_folder_naming_rule_default']); ?>" />
+						<div class="hint">
+							<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.'));?>
+						</div>
+					</div>
+				</div>
+			</section>
 		</div>
 		<?php print_unescaped($_['settingControls']); ?>
 	</fieldset>
 	<fieldset id="ldapSettings-2">
-		<p><strong><?php p($l->t('Internal Username'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
-		<p class="ldapIndent"><label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label><input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" /></p>
-		<p><strong><?php p($l->t('Override UUID detection'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
-		<p class="ldapIndent"><label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label><input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" /></p>
-		<p class="ldapIndent"><label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label><input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" /></p>
-		<p><strong><?php p($l->t('Username-LDAP User Mapping'));?></strong></p>
-		<p class="ldapIndent"><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
-		<p class="ldapIndent"><button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button><br/><button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button></p>
-		<?php print_unescaped($_['settingControls']); ?>
+		<section>
+			<h3><?php p($l->t('Internal Username'));?></h3>
+			<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
+			<div class="tablerow">
+				<label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label>
+				<input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" />
+			</div>
+		</section>
+		<section>
+			<h3><?php p($l->t('Override UUID detection'));?></h3>
+			<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
+			<div class="tablerow">
+				<label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label>
+				<input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" />
+			</div>
+			<div class="tablerow">
+				<label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label>
+				<input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" />
+			</div>
+		</section>
+		
+		<section>
+			<h3><?php p($l->t('Username-LDAP User Mapping'));?></h3>
+			<p><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
+			<div class="tablerow">
+				<button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button>
+				<button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button>
+			</div>
+			<?php print_unescaped($_['settingControls']); ?>
+		</section>
 	</fieldset>
 	</div>
 	<!-- Spinner Template -->

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -4,45 +4,45 @@
 vendor_script('user_ldap', 'ui-multiselect/src/jquery.multiselect');
 vendor_style('user_ldap', 'ui-multiselect/jquery.multiselect');
 script('user_ldap', [
-	'wizard/controller',
-	'wizard/configModel',
-	'wizard/view',
-	'wizard/wizardObject',
-	'wizard/wizardTabGeneric',
-	'wizard/wizardTabElementary',
-	'wizard/wizardTabAbstractFilter',
-	'wizard/wizardTabUserFilter',
-	'wizard/wizardTabLoginFilter',
-	'wizard/wizardTabGroupFilter',
-	'wizard/wizardTabAdvanced',
-	'wizard/wizardTabExpert',
-	'wizard/wizardDetectorQueue',
-	'wizard/wizardDetectorGeneric',
-	'wizard/wizardDetectorBaseDN',
-	'wizard/wizardDetectorFeatureAbstract',
-	'wizard/wizardDetectorUserObjectClasses',
-	'wizard/wizardDetectorGroupObjectClasses',
-	'wizard/wizardDetectorGroupsForUsers',
-	'wizard/wizardDetectorGroupsForGroups',
-	'wizard/wizardDetectorSimpleRequestAbstract',
-	'wizard/wizardDetectorFilterUser',
-	'wizard/wizardDetectorFilterLogin',
-	'wizard/wizardDetectorFilterGroup',
-	'wizard/wizardDetectorUserCount',
-	'wizard/wizardDetectorGroupCount',
-	'wizard/wizardDetectorEmailAttribute',
-	'wizard/wizardDetectorUserDisplayNameAttribute',
-	'wizard/wizardDetectorUserGroupAssociation',
-	'wizard/wizardDetectorAvailableAttributes',
-	'wizard/wizardDetectorTestAbstract',
-	'wizard/wizardDetectorTestLoginName',
-	'wizard/wizardDetectorTestBaseDN',
-	'wizard/wizardDetectorTestConfiguration',
-	'wizard/wizardDetectorClearUserMappings',
-	'wizard/wizardDetectorClearGroupMappings',
-	'wizard/wizardFilterOnType',
-	'wizard/wizardFilterOnTypeFactory',
-	'wizard/wizard'
+    'wizard/controller',
+    'wizard/configModel',
+    'wizard/view',
+    'wizard/wizardObject',
+    'wizard/wizardTabGeneric',
+    'wizard/wizardTabElementary',
+    'wizard/wizardTabAbstractFilter',
+    'wizard/wizardTabUserFilter',
+    'wizard/wizardTabLoginFilter',
+    'wizard/wizardTabGroupFilter',
+    'wizard/wizardTabAdvanced',
+    'wizard/wizardTabExpert',
+    'wizard/wizardDetectorQueue',
+    'wizard/wizardDetectorGeneric',
+    'wizard/wizardDetectorBaseDN',
+    'wizard/wizardDetectorFeatureAbstract',
+    'wizard/wizardDetectorUserObjectClasses',
+    'wizard/wizardDetectorGroupObjectClasses',
+    'wizard/wizardDetectorGroupsForUsers',
+    'wizard/wizardDetectorGroupsForGroups',
+    'wizard/wizardDetectorSimpleRequestAbstract',
+    'wizard/wizardDetectorFilterUser',
+    'wizard/wizardDetectorFilterLogin',
+    'wizard/wizardDetectorFilterGroup',
+    'wizard/wizardDetectorUserCount',
+    'wizard/wizardDetectorGroupCount',
+    'wizard/wizardDetectorEmailAttribute',
+    'wizard/wizardDetectorUserDisplayNameAttribute',
+    'wizard/wizardDetectorUserGroupAssociation',
+    'wizard/wizardDetectorAvailableAttributes',
+    'wizard/wizardDetectorTestAbstract',
+    'wizard/wizardDetectorTestLoginName',
+    'wizard/wizardDetectorTestBaseDN',
+    'wizard/wizardDetectorTestConfiguration',
+    'wizard/wizardDetectorClearUserMappings',
+    'wizard/wizardDetectorClearGroupMappings',
+    'wizard/wizardFilterOnType',
+    'wizard/wizardFilterOnTypeFactory',
+    'wizard/wizard'
 ]);
 
 style('user_ldap', 'settings');
@@ -54,13 +54,12 @@ style('user_ldap', 'settings');
 		<div class="header">
 			<h2 class="app-name"><?php p($l->t('LDAP')); ?><div class="ldap_config_state_indicator_container"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></div></h2>
 			<ul>
-				<?php foreach ($_['toc'] as $id => $title) 
-				{
-					?>
+				<?php foreach ($_['toc'] as $id => $title) {
+    ?>
 					<li id="<?php p($id); ?>"><a href="<?php p($id); ?>"><?php p($title); ?></a></li>
 					<?php
-				}
-				?>
+}
+                ?>
 				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
 				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
 				<li class="stateIndicator"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></li>
@@ -72,16 +71,14 @@ style('user_ldap', 'settings');
 				</li>
 			</ul>
 		</div>
-		<?php if (OCP\App::isEnabled('user_webdavauth'))
-		{
-			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
-		}
-		
-		if (!\function_exists('ldap_connect'))
-		{
-			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
-		}
-		?>
+		<?php if (OCP\App::isEnabled('user_webdavauth')) {
+                    print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
+                }
+        
+        if (!\function_exists('ldap_connect')) {
+            print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
+        }
+        ?>
 		<?php print_unescaped($_['tabs']); ?>
 		<fieldset id="ldapSettings-1">
 			<div id="ldapAdvancedAccordion">
@@ -189,9 +186,15 @@ style('user_ldap', 'settings');
 						<div class="tablerow">
 							<label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label>
 							<select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
-								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {p(' selected'); } ?>>uniqueMember</option>
-								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {p(' selected');} ?>>memberUid</option>
-								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {p(' selected');} ?>>member (AD)</option>
+								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {
+            p(' selected');
+        } ?>>uniqueMember</option>
+								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {
+            p(' selected');
+        } ?>>memberUid</option>
+								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {
+            p(' selected');
+        } ?>>member (AD)</option>
 							</select>
 						</div>
 						<div class="tablerow">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -42,7 +42,7 @@ script('user_ldap', [
     'wizard/wizardDetectorClearGroupMappings',
     'wizard/wizardFilterOnType',
     'wizard/wizardFilterOnTypeFactory',
-    'wizard/wizard'
+    'wizard/wizard',
 ]);
 
 style('user_ldap', 'settings');
@@ -60,13 +60,13 @@ style('user_ldap', 'settings');
 					<?php
 }
                 ?>
-				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
-				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
+				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced')); ?></a></li>
+				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert')); ?></a></li>
 				<li class="stateIndicator"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></li>
 				<li>
 					<a href="<?php p(link_to_docs('admin-ldap')); ?>" target="_blank" rel="noreferrer">
 						<img src="<?php print_unescaped(image_path('', 'actions/info.svg')); ?>" style="height:1.75ex" />
-						<span class="ldap_grey"><?php p($l->t('Help'));?></span>
+						<span class="ldap_grey"><?php p($l->t('Help')); ?></span>
 					</a>
 				</li>
 			</ul>
@@ -74,7 +74,7 @@ style('user_ldap', 'settings');
 		<?php if (OCP\App::isEnabled('user_webdavauth')) {
                     print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
                 }
-        
+
         if (!\function_exists('ldap_connect')) {
             print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
         }
@@ -83,170 +83,170 @@ style('user_ldap', 'settings');
 		<fieldset id="ldapSettings-1">
 			<div id="ldapAdvancedAccordion">
 				<section>
-					<h3><?php p($l->t('Connection Settings'));?></h3>
+					<h3><?php p($l->t('Connection Settings')); ?></h3>
 					<div>
 						<div class="tablerow">
-							<input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" />
-							<label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label>
+							<input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.')); ?>" />
+							<label for="ldap_configuration_active"><?php p($l->t('Configuration Active')); ?></label>
 						</div>
 
 						<div class="tablerow">
-							<label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label>
+							<label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host')); ?></label>
 							<input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>">
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port'));?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  />
+							<label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port')); ?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  />
 						</div>
 						<div class="tablerow">
-							<label for="ldap_override_main_server"><?php p($l->t('Disable Main Server'));?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"/>
+							<label for="ldap_override_main_server"><?php p($l->t('Disable Main Server')); ?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"/>
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Only connect to the replica server.'));?>
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Only connect to the replica server.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.'));?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1">
+							<label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.')); ?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1">
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName()));?>
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName())); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live'));?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" />
+							<label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live')); ?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('in seconds. A change empties the cache.'));?>
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('in seconds. A change empties the cache.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_network_timeout"><?php p($l->t('Network Timeout'));?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" data-default="<?php p($_['ldap_network_timeout_default']); ?>" />
+							<label for="ldap_network_timeout"><?php p($l->t('Network Timeout')); ?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" data-default="<?php p($_['ldap_network_timeout_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('timeout for all the ldap network operations, in seconds.'));?>
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('timeout for all the ldap network operations, in seconds.')); ?>
 							</div>
 						</div>
 					</div>
 				</section>
 
 				<section>
-					<h3><?php p($l->t('Directory Settings'));?></h3>
+					<h3><?php p($l->t('Directory Settings')); ?></h3>
 					<div>
 						<div class="tablerow">
-							<label for="ldap_display_name"><?php p($l->t('User Display Name Field'));?></label>
+							<label for="ldap_display_name"><?php p($l->t('User Display Name Field')); ?></label>
 							<input type="text" id="ldap_display_name" name="ldap_display_name" data-default="<?php p($_['ldap_display_name_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the user\'s display name.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the user\'s display name.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field'));?></label>
+							<label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field')); ?></label>
 							<input type="text" id="ldap_user_display_name_2" name="ldap_user_display_name_2" data-default="<?php p($_['ldap_user_display_name_2_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_base_users"><?php p($l->t('Base User Tree'));?></label>
-							<textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line'));?>" data-default="<?php p($_['ldap_base_users_default']); ?>"></textarea>
+							<label for="ldap_base_users"><?php p($l->t('Base User Tree')); ?></label>
+							<textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line')); ?>" data-default="<?php p($_['ldap_base_users_default']); ?>"></textarea>
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base User Tree'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base User Tree')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes'));?></label>
-							<textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>"></textarea>
+							<label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes')); ?></label>
+							<textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line')); ?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>"></textarea>
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('User Search Attributes'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('User Search Attributes')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
 							<label></label>
-							<small><?php p($l->t('Each attribute value is truncated to 191 characters'));?></small>
+							<small><?php p($l->t('Each attribute value is truncated to 191 characters')); ?></small>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field'));?></label>
+							<label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field')); ?></label>
 							<input type="text" id="ldap_group_display_name" name="ldap_group_display_name" data-default="<?php p($_['ldap_group_display_name_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_base_groups"><?php p($l->t('Base Group Tree'));?></label>
-							<textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line'));?>" data-default="<?php p($_['ldap_base_groups_default']); ?>"></textarea>
+							<label for="ldap_base_groups"><?php p($l->t('Base Group Tree')); ?></label>
+							<textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line')); ?>" data-default="<?php p($_['ldap_base_groups_default']); ?>"></textarea>
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base Group Tree'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base Group Tree')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes'));?></label>
-							<textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>"></textarea>
+							<label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes')); ?></label>
+							<textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line')); ?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>"></textarea>
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Group Search Attributes'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Group Search Attributes')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label>
+							<label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association')); ?></label>
 							<select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
-								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {
+								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('uniqueMember' === $_['ldap_group_member_assoc_attribute'])) {
             p(' selected');
         } ?>>uniqueMember</option>
-								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {
+								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('memberUid' === $_['ldap_group_member_assoc_attribute'])) {
             p(' selected');
         } ?>>memberUid</option>
-								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {
+								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('member' === $_['ldap_group_member_assoc_attribute'])) {
             p(' selected');
         } ?>>member (AD)</option>
 							</select>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL'));?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" />
+							<label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL')); ?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_nested_groups"><?php p($l->t('Nested Groups'));?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>" />
+							<label for="ldap_nested_groups"><?php p($l->t('Nested Groups')); ?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_paging_size"><?php p($l->t('Paging chunksize'));?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" data-default="<?php p($_['ldap_paging_size_default']); ?>" />
+							<label for="ldap_paging_size"><?php p($l->t('Paging chunksize')); ?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" data-default="<?php p($_['ldap_paging_size_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)')); ?>
 							</div>
 						</div>
 					</div>
 				</section>
 
 				<section>
-					<h3><?php p($l->t('Special Attributes'));?></h3>
+					<h3><?php p($l->t('Special Attributes')); ?></h3>
 					<div>
 						<div class="tablerow">
-							<label for="ldap_quota_attr"><?php p($l->t('Quota Field'));?></label>
+							<label for="ldap_quota_attr"><?php p($l->t('Quota Field')); ?></label>
 							<input type="text" id="ldap_quota_attr" name="ldap_quota_attr" data-default="<?php p($_['ldap_quota_attr_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_quota_def"><?php p($l->t('Quota Default'));?></label>
+							<label for="ldap_quota_def"><?php p($l->t('Quota Default')); ?></label>
 							<input type="text" id="ldap_quota_def" name="ldap_quota_def" data-default="<?php p($_['ldap_quota_def_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="ldap_email_attr"><?php p($l->t('Email Field'));?></label>
+							<label for="ldap_email_attr"><?php p($l->t('Email Field')); ?></label>
 							<input type="text" id="ldap_email_attr" name="ldap_email_attr" data-default="<?php p($_['ldap_email_attr_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.')); ?>
 							</div>
 						</div>
 						<div class="tablerow">
-							<label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule'));?></label>
+							<label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule')); ?></label>
 							<input type="text" id="home_folder_naming_rule" name="home_folder_naming_rule" data-default="<?php p($_['home_folder_naming_rule_default']); ?>" />
 							<div class="hint">
-								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.'));?>
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.')); ?>
 							</div>
 						</div>
 					</div>
@@ -256,32 +256,32 @@ style('user_ldap', 'settings');
 		</fieldset>
 		<fieldset id="ldapSettings-2">
 			<section>
-				<h3><?php p($l->t('Internal Username'));?></h3>
-				<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
+				<h3><?php p($l->t('Internal Username')); ?></h3>
+				<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.')); ?></p>
 				<div class="tablerow">
-					<label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label>
+					<label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:')); ?></label>
 					<input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" />
 				</div>
 			</section>
 			<section>
-				<h3><?php p($l->t('Override UUID detection'));?></h3>
-				<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
+				<h3><?php p($l->t('Override UUID detection')); ?></h3>
+				<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.')); ?></p>
 				<div class="tablerow">
-					<label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label>
+					<label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:')); ?></label>
 					<input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" />
 				</div>
 				<div class="tablerow">
-					<label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label>
+					<label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:')); ?></label>
 					<input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" />
 				</div>
 			</section>
 			
 			<section>
-				<h3><?php p($l->t('Username-LDAP User Mapping'));?></h3>
-				<p><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
+				<h3><?php p($l->t('Username-LDAP User Mapping')); ?></h3>
+				<p><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.')); ?></p>
 				<div class="tablerow">
-					<button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button>
-					<button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button>
+					<button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping')); ?></button>
+					<button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping')); ?></button>
 				</div>
 				<?php print_unescaped($_['settingControls']); ?>
 			</section>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -4,45 +4,45 @@
 vendor_script('user_ldap', 'ui-multiselect/src/jquery.multiselect');
 vendor_style('user_ldap', 'ui-multiselect/jquery.multiselect');
 script('user_ldap', [
-    'wizard/controller',
-    'wizard/configModel',
-    'wizard/view',
-    'wizard/wizardObject',
-    'wizard/wizardTabGeneric',
-    'wizard/wizardTabElementary',
-    'wizard/wizardTabAbstractFilter',
-    'wizard/wizardTabUserFilter',
-    'wizard/wizardTabLoginFilter',
-    'wizard/wizardTabGroupFilter',
-    'wizard/wizardTabAdvanced',
-    'wizard/wizardTabExpert',
-    'wizard/wizardDetectorQueue',
-    'wizard/wizardDetectorGeneric',
-    'wizard/wizardDetectorBaseDN',
-    'wizard/wizardDetectorFeatureAbstract',
-    'wizard/wizardDetectorUserObjectClasses',
-    'wizard/wizardDetectorGroupObjectClasses',
-    'wizard/wizardDetectorGroupsForUsers',
-    'wizard/wizardDetectorGroupsForGroups',
-    'wizard/wizardDetectorSimpleRequestAbstract',
-    'wizard/wizardDetectorFilterUser',
-    'wizard/wizardDetectorFilterLogin',
-    'wizard/wizardDetectorFilterGroup',
-    'wizard/wizardDetectorUserCount',
-    'wizard/wizardDetectorGroupCount',
-    'wizard/wizardDetectorEmailAttribute',
-    'wizard/wizardDetectorUserDisplayNameAttribute',
-    'wizard/wizardDetectorUserGroupAssociation',
-    'wizard/wizardDetectorAvailableAttributes',
-    'wizard/wizardDetectorTestAbstract',
-    'wizard/wizardDetectorTestLoginName',
-    'wizard/wizardDetectorTestBaseDN',
-    'wizard/wizardDetectorTestConfiguration',
-    'wizard/wizardDetectorClearUserMappings',
-    'wizard/wizardDetectorClearGroupMappings',
-    'wizard/wizardFilterOnType',
-    'wizard/wizardFilterOnTypeFactory',
-    'wizard/wizard',
+	'wizard/controller',
+	'wizard/configModel',
+	'wizard/view',
+	'wizard/wizardObject',
+	'wizard/wizardTabGeneric',
+	'wizard/wizardTabElementary',
+	'wizard/wizardTabAbstractFilter',
+	'wizard/wizardTabUserFilter',
+	'wizard/wizardTabLoginFilter',
+	'wizard/wizardTabGroupFilter',
+	'wizard/wizardTabAdvanced',
+	'wizard/wizardTabExpert',
+	'wizard/wizardDetectorQueue',
+	'wizard/wizardDetectorGeneric',
+	'wizard/wizardDetectorBaseDN',
+	'wizard/wizardDetectorFeatureAbstract',
+	'wizard/wizardDetectorUserObjectClasses',
+	'wizard/wizardDetectorGroupObjectClasses',
+	'wizard/wizardDetectorGroupsForUsers',
+	'wizard/wizardDetectorGroupsForGroups',
+	'wizard/wizardDetectorSimpleRequestAbstract',
+	'wizard/wizardDetectorFilterUser',
+	'wizard/wizardDetectorFilterLogin',
+	'wizard/wizardDetectorFilterGroup',
+	'wizard/wizardDetectorUserCount',
+	'wizard/wizardDetectorGroupCount',
+	'wizard/wizardDetectorEmailAttribute',
+	'wizard/wizardDetectorUserDisplayNameAttribute',
+	'wizard/wizardDetectorUserGroupAssociation',
+	'wizard/wizardDetectorAvailableAttributes',
+	'wizard/wizardDetectorTestAbstract',
+	'wizard/wizardDetectorTestLoginName',
+	'wizard/wizardDetectorTestBaseDN',
+	'wizard/wizardDetectorTestConfiguration',
+	'wizard/wizardDetectorClearUserMappings',
+	'wizard/wizardDetectorClearGroupMappings',
+	'wizard/wizardFilterOnType',
+	'wizard/wizardFilterOnTypeFactory',
+	'wizard/wizard',
 ]);
 
 style('user_ldap', 'settings');
@@ -55,11 +55,11 @@ style('user_ldap', 'settings');
 			<h2 class="app-name"><?php p($l->t('LDAP')); ?><div class="ldap_config_state_indicator_container"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></div></h2>
 			<ul>
 				<?php foreach ($_['toc'] as $id => $title) {
-    ?>
+	?>
 					<li id="<?php p($id); ?>"><a href="<?php p($id); ?>"><?php p($title); ?></a></li>
 					<?php
 }
-                ?>
+				?>
 				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced')); ?></a></li>
 				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert')); ?></a></li>
 				<li class="stateIndicator"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></li>
@@ -72,13 +72,13 @@ style('user_ldap', 'settings');
 			</ul>
 		</div>
 		<?php if (OCP\App::isEnabled('user_webdavauth')) {
-                    print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
-                }
+					print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
+				}
 
-        if (!\function_exists('ldap_connect')) {
-            print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
-        }
-        ?>
+		if (!\function_exists('ldap_connect')) {
+			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
+		}
+		?>
 		<?php print_unescaped($_['tabs']); ?>
 		<fieldset id="ldapSettings-1">
 			<div id="ldapAdvancedAccordion">
@@ -186,15 +186,15 @@ style('user_ldap', 'settings');
 						<div class="tablerow">
 							<label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association')); ?></label>
 							<select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
-								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('uniqueMember' === $_['ldap_group_member_assoc_attribute'])) {
-            p(' selected');
-        } ?>>uniqueMember</option>
-								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('memberUid' === $_['ldap_group_member_assoc_attribute'])) {
-            p(' selected');
-        } ?>>memberUid</option>
-								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ('member' === $_['ldap_group_member_assoc_attribute'])) {
-            p(' selected');
-        } ?>>member (AD)</option>
+								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {
+			p(' selected');
+		} ?>>uniqueMember</option>
+								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {
+			p(' selected');
+		} ?>>memberUid</option>
+								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {
+			p(' selected');
+		} ?>>member (AD)</option>
 							</select>
 						</div>
 						<div class="tablerow">

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -50,235 +50,239 @@ style('user_ldap', 'settings');
 ?>
 
 <form id="ldap" class="section" action="#" method="post">
-		<div id="ldapSettings">
-			<div class="header">
+	<div id="ldapSettings">
+		<div class="header">
 			<h2 class="app-name"><?php p($l->t('LDAP')); ?><div class="ldap_config_state_indicator_container"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></div></h2>
 			<ul>
-				<?php foreach ($_['toc'] as $id => $title) {?>
+				<?php foreach ($_['toc'] as $id => $title) 
+				{
+					?>
 					<li id="<?php p($id); ?>"><a href="<?php p($id); ?>"><?php p($title); ?></a></li>
-				<?php
-				} ?>
+					<?php
+				}
+				?>
 				<li class="warn"><a href="#ldapSettings-1"><?php p($l->t('Advanced'));?></a></li>
 				<li class="warn"><a href="#ldapSettings-2"><?php p($l->t('Expert'));?></a></li>
 				<li class="stateIndicator"><span class="ldap_config_state_indicator"></span> <span class="ldap_config_state_indicator_sign"></span></li>
 				<li>
-					<div>
 					<a href="<?php p(link_to_docs('admin-ldap')); ?>" target="_blank" rel="noreferrer">
 						<img src="<?php print_unescaped(image_path('', 'actions/info.svg')); ?>" style="height:1.75ex" />
 						<span class="ldap_grey"><?php p($l->t('Help'));?></span>
 					</a>
-					<div>
 				</li>
 			</ul>
-			</div>
-			<?php if (OCP\App::isEnabled('user_webdavauth')) {
-				print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
-			}
-			if (!\function_exists('ldap_connect')) {
-				print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
-			}
-			?>
-	<?php print_unescaped($_['tabs']); ?>
-	<fieldset id="ldapSettings-1">
-		<div id="ldapAdvancedAccordion">
-			<section>
-				<h3><?php p($l->t('Connection Settings'));?></h3>
-				<div>
-					<div class="tablerow">
-						<input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" />
-						<label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label>
-					</div>
-
-					<div class="tablerow">
-						<label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label>
-						<input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>">
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port'));?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  />
-					</div>
-					<div class="tablerow">
-						<label for="ldap_override_main_server"><?php p($l->t('Disable Main Server'));?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"/>
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Only connect to the replica server.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.'));?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1">
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName()));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live'));?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('in seconds. A change empties the cache.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_network_timeout"><?php p($l->t('Network Timeout'));?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" data-default="<?php p($_['ldap_network_timeout_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('timeout for all the ldap network operations, in seconds.'));?>
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<section>
-				<h3><?php p($l->t('Directory Settings'));?></h3>
-				<div>
-					<div class="tablerow">
-						<label for="ldap_display_name"><?php p($l->t('User Display Name Field'));?></label>
-						<input type="text" id="ldap_display_name" name="ldap_display_name" data-default="<?php p($_['ldap_display_name_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the user\'s display name.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field'));?></label>
-						<input type="text" id="ldap_user_display_name_2" name="ldap_user_display_name_2" data-default="<?php p($_['ldap_user_display_name_2_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_base_users"><?php p($l->t('Base User Tree'));?></label>
-						<textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line'));?>" data-default="<?php p($_['ldap_base_users_default']); ?>"></textarea>
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Base User Tree'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes'));?></label>
-						<textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>"></textarea>
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('User Search Attributes'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label></label>
-						<small><?php p($l->t('Each attribute value is truncated to 191 characters'));?></small>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field'));?></label>
-						<input type="text" id="ldap_group_display_name" name="ldap_group_display_name" data-default="<?php p($_['ldap_group_display_name_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_base_groups"><?php p($l->t('Base Group Tree'));?></label>
-						<textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line'));?>" data-default="<?php p($_['ldap_base_groups_default']); ?>"></textarea>
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Base Group Tree'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes'));?></label>
-						<textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>"></textarea>
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Group Search Attributes'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-                        <label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label>
-                        <select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
-                            <option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {p(' selected'); } ?>>uniqueMember</option>
-                            <option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {p(' selected');} ?>>memberUid</option>
-                            <option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {p(' selected');} ?>>member (AD)</option>
-                        </select>
-                    </div>
-					<div class="tablerow">
-						<label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL'));?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_nested_groups"><?php p($l->t('Nested Groups'));?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)'));?>
-						</div>
-					</div>
-                    <div class="tablerow">
-						<label for="ldap_paging_size"><?php p($l->t('Paging chunksize'));?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" data-default="<?php p($_['ldap_paging_size_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)'));?>
-						</div>
-					</div>
-				</div>
-			</section>
-
-			<section>
-				<h3><?php p($l->t('Special Attributes'));?></h3>
-				<div>
-					<div class="tablerow">
-						<label for="ldap_quota_attr"><?php p($l->t('Quota Field'));?></label>
-						<input type="text" id="ldap_quota_attr" name="ldap_quota_attr" data-default="<?php p($_['ldap_quota_attr_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_quota_def"><?php p($l->t('Quota Default'));?></label>
-						<input type="text" id="ldap_quota_def" name="ldap_quota_def" data-default="<?php p($_['ldap_quota_def_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="ldap_email_attr"><?php p($l->t('Email Field'));?></label>
-						<input type="text" id="ldap_email_attr" name="ldap_email_attr" data-default="<?php p($_['ldap_email_attr_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.'));?>
-						</div>
-					</div>
-					<div class="tablerow">
-						<label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule'));?></label>
-						<input type="text" id="home_folder_naming_rule" name="home_folder_naming_rule" data-default="<?php p($_['home_folder_naming_rule_default']); ?>" />
-						<div class="hint">
-							<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.'));?>
-						</div>
-					</div>
-				</div>
-			</section>
 		</div>
-		<?php print_unescaped($_['settingControls']); ?>
-	</fieldset>
-	<fieldset id="ldapSettings-2">
-		<section>
-			<h3><?php p($l->t('Internal Username'));?></h3>
-			<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
-			<div class="tablerow">
-				<label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label>
-				<input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" />
-			</div>
-		</section>
-		<section>
-			<h3><?php p($l->t('Override UUID detection'));?></h3>
-			<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
-			<div class="tablerow">
-				<label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label>
-				<input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" />
-			</div>
-			<div class="tablerow">
-				<label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label>
-				<input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" />
-			</div>
-		</section>
+		<?php if (OCP\App::isEnabled('user_webdavauth'))
+		{
+			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> Apps user_ldap and user_webdavauth are incompatible. You may experience unexpected behavior. Please ask your system administrator to disable one of them.').'</p>');
+		}
 		
-		<section>
-			<h3><?php p($l->t('Username-LDAP User Mapping'));?></h3>
-			<p><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
-			<div class="tablerow">
-				<button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button>
-				<button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button>
+		if (!\function_exists('ldap_connect'))
+		{
+			print_unescaped('<p class="ldapwarning">'.$l->t('<b>Warning:</b> The PHP LDAP module is not installed, the backend will not work. Please ask your system administrator to install it.').'</p>');
+		}
+		?>
+		<?php print_unescaped($_['tabs']); ?>
+		<fieldset id="ldapSettings-1">
+			<div id="ldapAdvancedAccordion">
+				<section>
+					<h3><?php p($l->t('Connection Settings'));?></h3>
+					<div>
+						<div class="tablerow">
+							<input type="checkbox" id="ldap_configuration_active" name="ldap_configuration_active" value="1" data-default="<?php p($_['ldap_configuration_active_default']); ?>"  title="<?php p($l->t('When unchecked, this configuration will be skipped.'));?>" />
+							<label for="ldap_configuration_active"><?php p($l->t('Configuration Active'));?></label>
+						</div>
+
+						<div class="tablerow">
+							<label for="ldap_backup_host"><?php p($l->t('Backup (Replica) Host'));?></label>
+							<input type="text" id="ldap_backup_host" name="ldap_backup_host" data-default="<?php p($_['ldap_backup_host_default']); ?>">
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Give an optional backup host. It must be a replica of the main LDAP/AD server.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_backup_port"><?php p($l->t('Backup (Replica) Port'));?></label><input type="number" id="ldap_backup_port" name="ldap_backup_port" data-default="<?php p($_['ldap_backup_port_default']); ?>"  />
+						</div>
+						<div class="tablerow">
+							<label for="ldap_override_main_server"><?php p($l->t('Disable Main Server'));?></label><input type="checkbox" id="ldap_override_main_server" name="ldap_override_main_server" value="1" data-default="<?php p($_['ldap_override_main_server_default']); ?>"/>
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Only connect to the replica server.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_turn_off_cert_check"><?php p($l->t('Turn off SSL certificate validation.'));?></label><input type="checkbox" id="ldap_turn_off_cert_check" name="ldap_turn_off_cert_check" data-default="<?php p($_['ldap_turn_off_cert_check_default']); ?>" value="1">
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('Not recommended, use it for testing only! If connection only works with this option, import the LDAP server\'s SSL certificate in your %s server.', $theme->getName()));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_cache_ttl"><?php p($l->t('Cache Time-To-Live'));?></label><input type="number" id="ldap_cache_ttl" name="ldap_cache_ttl" data-default="<?php p($_['ldap_cache_ttl_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('in seconds. A change empties the cache.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_network_timeout"><?php p($l->t('Network Timeout'));?></label><input type="number" id="ldap_network_timeout" name="ldap_network_timeout" data-default="<?php p($_['ldap_network_timeout_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" class=""> <?php p($l->t('timeout for all the ldap network operations, in seconds.'));?>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section>
+					<h3><?php p($l->t('Directory Settings'));?></h3>
+					<div>
+						<div class="tablerow">
+							<label for="ldap_display_name"><?php p($l->t('User Display Name Field'));?></label>
+							<input type="text" id="ldap_display_name" name="ldap_display_name" data-default="<?php p($_['ldap_display_name_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the user\'s display name.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_user_display_name_2"><?php p($l->t('2nd User Display Name Field'));?></label>
+							<input type="text" id="ldap_user_display_name_2" name="ldap_user_display_name_2" data-default="<?php p($_['ldap_user_display_name_2_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Optional. An LDAP attribute to be added to the display name in brackets. Results in e.g. »John Doe (john.doe@example.org)«.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_base_users"><?php p($l->t('Base User Tree'));?></label>
+							<textarea id="ldap_base_users" name="ldap_base_users" placeholder="<?php p($l->t('One User Base DN per line'));?>" data-default="<?php p($_['ldap_base_users_default']); ?>"></textarea>
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base User Tree'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_attributes_for_user_search"><?php p($l->t('User Search Attributes'));?></label>
+							<textarea id="ldap_attributes_for_user_search" name="ldap_attributes_for_user_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_user_search_default']); ?>"></textarea>
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('User Search Attributes'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label></label>
+							<small><?php p($l->t('Each attribute value is truncated to 191 characters'));?></small>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_group_display_name"><?php p($l->t('Group Display Name Field'));?></label>
+							<input type="text" id="ldap_group_display_name" name="ldap_group_display_name" data-default="<?php p($_['ldap_group_display_name_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute to use to generate the groups\'s display name.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_base_groups"><?php p($l->t('Base Group Tree'));?></label>
+							<textarea id="ldap_base_groups" name="ldap_base_groups" placeholder="<?php p($l->t('One Group Base DN per line'));?>" data-default="<?php p($_['ldap_base_groups_default']); ?>"></textarea>
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Base Group Tree'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_attributes_for_group_search"><?php p($l->t('Group Search Attributes'));?></label>
+							<textarea id="ldap_attributes_for_group_search" name="ldap_attributes_for_group_search" placeholder="<?php p($l->t('Optional; one attribute per line'));?>" data-default="<?php p($_['ldap_attributes_for_group_search_default']); ?>"></textarea>
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Group Search Attributes'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_group_member_assoc_attribute"><?php p($l->t('Group-Member association'));?></label>
+							<select id="ldap_group_member_assoc_attribute" name="ldap_group_member_assoc_attribute" data-default="<?php p($_['ldap_group_member_assoc_attribute_default']); ?>" >
+								<option value="uniqueMember"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'uniqueMember')) {p(' selected'); } ?>>uniqueMember</option>
+								<option value="memberUid"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'memberUid')) {p(' selected');} ?>>memberUid</option>
+								<option value="member"<?php if (isset($_['ldap_group_member_assoc_attribute']) && ($_['ldap_group_member_assoc_attribute'] === 'member')) {p(' selected');} ?>>member (AD)</option>
+							</select>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_dynamic_group_member_url"><?php p($l->t('Dynamic Group Member URL'));?></label><input type="text" id="ldap_dynamic_group_member_url" name="ldap_dynamic_group_member_url" data-default="<?php p($_['ldap_dynamic_group_member_url_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('The LDAP attribute that on group objects contains an LDAP search URL that determines what objects belong to the group. (An empty setting disables dynamic group membership functionality.)'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_nested_groups"><?php p($l->t('Nested Groups'));?></label><input type="checkbox" id="ldap_nested_groups" name="ldap_nested_groups" value="1" data-default="<?php p($_['ldap_nested_groups_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('When switched on, groups that contain groups are supported. (Only works if the group member attribute contains DNs.)'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_paging_size"><?php p($l->t('Paging chunksize'));?></label><input type="number" id="ldap_paging_size" name="ldap_paging_size" data-default="<?php p($_['ldap_paging_size_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Chunksize used for paged LDAP searches that may return bulky results like user or group enumeration. (Setting it 0 disables paged LDAP searches in those situations.)'));?>
+							</div>
+						</div>
+					</div>
+				</section>
+
+				<section>
+					<h3><?php p($l->t('Special Attributes'));?></h3>
+					<div>
+						<div class="tablerow">
+							<label for="ldap_quota_attr"><?php p($l->t('Quota Field'));?></label>
+							<input type="text" id="ldap_quota_attr" name="ldap_quota_attr" data-default="<?php p($_['ldap_quota_attr_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user\'s default quota. Otherwise, specify an LDAP/AD attribute.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_quota_def"><?php p($l->t('Quota Default'));?></label>
+							<input type="text" id="ldap_quota_def" name="ldap_quota_def" data-default="<?php p($_['ldap_quota_def_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Override default quota for LDAP users who do not have a quota set in the Quota Field.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="ldap_email_attr"><?php p($l->t('Email Field'));?></label>
+							<input type="text" id="ldap_email_attr" name="ldap_email_attr" data-default="<?php p($_['ldap_email_attr_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Set the user\'s email from their LDAP attribute. Leave it empty for default behaviour.'));?>
+							</div>
+						</div>
+						<div class="tablerow">
+							<label for="home_folder_naming_rule"><?php p($l->t('User Home Folder Naming Rule'));?></label>
+							<input type="text" id="home_folder_naming_rule" name="home_folder_naming_rule" data-default="<?php p($_['home_folder_naming_rule_default']); ?>" />
+							<div class="hint">
+								<img src="/core/img/actions/info.svg" > <?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.'));?>
+							</div>
+						</div>
+					</div>
+				</section>
 			</div>
 			<?php print_unescaped($_['settingControls']); ?>
-		</section>
-	</fieldset>
+		</fieldset>
+		<fieldset id="ldapSettings-2">
+			<section>
+				<h3><?php p($l->t('Internal Username'));?></h3>
+				<p><?php p($l->t('By default the internal username will be created from the UUID attribute. It makes sure that the username is unique and characters do not need to be converted. The internal username has the restriction that only these characters are allowed: [ a-zA-Z0-9+_.@- ].  Other characters are replaced with their ASCII correspondence or simply omitted. On collisions a number will be added/increased. The internal username is used to identify a user internally. It is also the default name for the user home folder. It is also a part of remote URLs, for instance for all *DAV services. With this setting, the default behavior can be overridden. To achieve a similar behavior as before ownCloud 5 enter the user display name attribute in the following field. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users.'));?></p>
+				<div class="tablerow">
+					<label for="ldap_expert_username_attr"><?php p($l->t('Internal Username Attribute:'));?></label>
+					<input type="text" id="ldap_expert_username_attr" name="ldap_expert_username_attr" data-default="<?php p($_['ldap_expert_username_attr_default']); ?>" />
+				</div>
+			</section>
+			<section>
+				<h3><?php p($l->t('Override UUID detection'));?></h3>
+				<p><?php p($l->t('By default, the UUID attribute is automatically detected. The UUID attribute is used to doubtlessly identify LDAP users and groups. Also, the internal username will be created based on the UUID, if not specified otherwise above. You can override the setting and pass an attribute of your choice. You must make sure that the attribute of your choice can be fetched for both users and groups and it is unique. Leave it empty for default behavior. Changes will have effect only on newly mapped (added) LDAP users and groups.'));?></p>
+				<div class="tablerow">
+					<label for="ldap_expert_uuid_user_attr"><?php p($l->t('UUID Attribute for Users:'));?></label>
+					<input type="text" id="ldap_expert_uuid_user_attr" name="ldap_expert_uuid_user_attr" data-default="<?php p($_['ldap_expert_uuid_user_attr_default']); ?>" />
+				</div>
+				<div class="tablerow">
+					<label for="ldap_expert_uuid_group_attr"><?php p($l->t('UUID Attribute for Groups:'));?></label>
+					<input type="text" id="ldap_expert_uuid_group_attr" name="ldap_expert_uuid_group_attr" data-default="<?php p($_['ldap_expert_uuid_group_attr_default']); ?>" />
+				</div>
+			</section>
+			
+			<section>
+				<h3><?php p($l->t('Username-LDAP User Mapping'));?></h3>
+				<p><?php p($l->t('Usernames are used to store and assign (meta) data. In order to precisely identify and recognize users, each LDAP user will have an internal username. This requires a mapping from username to LDAP user. The created username is mapped to the UUID of the LDAP user. Additionally the DN is cached as well to reduce LDAP interaction, but it is not used for identification. If the DN changes, the changes will be found. The internal username is used all over. Clearing the mappings will have leftovers everywhere. Clearing the mappings is not configuration sensitive, it affects all LDAP configurations! Never clear the mappings in a production environment, only in a testing or experimental stage.'));?></p>
+				<div class="tablerow">
+					<button type="button" id="ldap_action_clear_user_mappings" name="ldap_action_clear_user_mappings"><?php p($l->t('Clear Username-LDAP User Mapping'));?></button>
+					<button type="button" id="ldap_action_clear_group_mappings" name="ldap_action_clear_group_mappings"><?php p($l->t('Clear Groupname-LDAP Group Mapping'));?></button>
+				</div>
+				<?php print_unescaped($_['settingControls']); ?>
+			</section>
+		</fieldset>
 	</div>
 	<!-- Spinner Template -->
 	<img class="ldapSpinner hidden" src="<?php p(image_path('core', 'loading.gif')); ?>">


### PR DESCRIPTION
Hi,
while working on an ldap implementation in a custom theme I update this app to have a more modern look.
Note: Those are only design changes. No functional changes were made.

# General look
- General look is now more unified
- Advanced/Expert tabs have a warning icon to emphasize that those are critical settings
- Connection test icon was moved to the tab bar to have it visible at all time (before users had to scroll down to check)
- Results of config tests are displayed always besides test buttons (before results were shown besides button or as OC Notification sometimes)
- Repsonsiveness was added (elements resize based on media queries)
- Correct use of HTML elements

before:
<img width="1440" alt="Bildschirmfoto 2020-10-22 um 12 59 52" src="https://user-images.githubusercontent.com/16665512/96877817-6bad0980-147a-11eb-814a-d99361e711e2.png">

after:
<img width="1440" alt="Bildschirmfoto 2020-10-22 um 15 21 50" src="https://user-images.githubusercontent.com/16665512/96877848-736cae00-147a-11eb-8567-0b2948dfaaf1.png">

## Fixed top bar
- Tab bar is a fixed element, tabs, test indicator icon, help are always visible now (see gif)
before:
![scroll_before](https://user-images.githubusercontent.com/16665512/96878976-c2671300-147b-11eb-803d-ac8406f9f4fa.gif)

after:
![scroll](https://user-images.githubusercontent.com/16665512/96878997-c7c45d80-147b-11eb-8bb4-5b22949ce197.gif)


# Input labels & Hints
Placeholder values were the names of the fields. If a user entered a value the name (=placeholder) dissappeared. All input fields have labels now so users know anytime which input is expected.
Also helping tips were hidden in mouseover tooltips. Tips are now displayed below input fields to have them visible at any time.

before:
<img width="812" alt="Bildschirmfoto 2020-10-22 um 13 00 58" src="https://user-images.githubusercontent.com/16665512/96877990-9f882f00-147a-11eb-947e-516269ece3d5.png">

after:
<img width="709" alt="Bildschirmfoto 2020-10-22 um 13 01 53" src="https://user-images.githubusercontent.com/16665512/96878176-d0686400-147a-11eb-8fb2-2ad995bdb668.png">

# Advanced settings
Advanced settings were displayed as an accordion which hides some settings and the user is forced to open them manually.
Accordion was removed to have all settings visible at the same time.

before:
<img width="1169" alt="Bildschirmfoto 2020-10-22 um 13 02 52" src="https://user-images.githubusercontent.com/16665512/96878671-69977a80-147b-11eb-9eef-3fa45687b2bf.png">

after:
<img width="1117" alt="Bildschirmfoto 2020-10-22 um 13 02 35" src="https://user-images.githubusercontent.com/16665512/96878696-70be8880-147b-11eb-8f67-b78d19da26f4.png">

