### PR TITLE
Fixed read LDAP attribute value 0 returned as null

### DIFF
--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -81,7 +81,7 @@ class User_Proxy extends Proxy implements
 				&& \method_exists($this->getAccess($configPrefix), $method)) {
 				$instance = $this->getAccess($configPrefix);
 			}
-			if ($result = \call_user_func_array([$instance, $method], $parameters)) {
+			if (($result = \call_user_func_array([$instance, $method], $parameters)) !== false) {
 				$this->writeToCache($cacheKey, $configPrefix);
 				return $result;
 			}


### PR DESCRIPTION
I noticed that when sync'ing LDAP users with a quota of "0", they were stored with a quota of NULL. The reason is that there's a soft comparison here:

```
	protected function walkBackends($uid, $method, $parameters) {
		$cacheKey = $this->getUserCacheKey($uid);
		foreach ($this->backends as $configPrefix => $backend) {
			$instance = $backend;
			if (!\method_exists($instance, $method)
				&& \method_exists($this->getAccess($configPrefix), $method)) {
				$instance = $this->getAccess($configPrefix);
			}
			if ($result = \call_user_func_array([$instance, $method], $parameters)) {
				$this->writeToCache($cacheKey, $configPrefix);
				return $result;
			}
		}
		return false;
	}
```

So when call_user_func_array returns "0" it is considered "false", the value is not cached nor returned, and the method returns "false".

Just adding !== false solves the problem. Now my users with quota "0" are synchronized correctly and they show "0" in the oc_accounts table rather than NULL.
