### PR TITLE
[tests-only] Run nightly encryption tests with daily-master-qa

### DIFF
--- a/.drone.starlark
+++ b/.drone.starlark
@@ -551,7 +551,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',
@@ -615,7 +615,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',
@@ -665,7 +665,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',
@@ -730,7 +730,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',
@@ -794,7 +794,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',
@@ -844,7 +844,7 @@ config = {
 				'mysql:5.7',
 			],
 			'servers': [
-				'latest',
+				'daily-master-qa',
 			],
 			'phpVersions': [
 				'7.2',

--- a/.drone.yml
+++ b/.drone.yml
@@ -22588,7 +22588,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-1-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-1-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -22610,7 +22610,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -22631,7 +22631,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -22796,7 +22796,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-2-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-2-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -22818,7 +22818,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -22839,7 +22839,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -23004,7 +23004,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-3-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-3-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -23026,7 +23026,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -23047,7 +23047,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -23212,7 +23212,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-4-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-4-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -23234,7 +23234,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -23255,7 +23255,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -23420,7 +23420,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-5-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-5-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -23442,7 +23442,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -23463,7 +23463,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -23628,7 +23628,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-6-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-6-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -23650,7 +23650,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -23671,7 +23671,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -23836,7 +23836,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-7-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-7-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -23858,7 +23858,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -23879,7 +23879,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -24044,7 +24044,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-8-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-8-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -24066,7 +24066,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -24087,7 +24087,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -24252,7 +24252,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-9-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-9-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -24274,7 +24274,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -24295,7 +24295,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -24460,7 +24460,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-10-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-10-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -24482,7 +24482,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -24503,7 +24503,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -24668,7 +24668,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-11-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-11-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -24690,7 +24690,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -24711,7 +24711,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -24876,7 +24876,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-12-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-12-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -24898,7 +24898,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -24919,7 +24919,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -25084,7 +25084,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-13-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-13-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -25106,7 +25106,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -25127,7 +25127,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -25292,7 +25292,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-14-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-14-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -25314,7 +25314,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -25335,7 +25335,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -25500,7 +25500,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-15-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-15-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -25522,7 +25522,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -25543,7 +25543,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -25708,7 +25708,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-16-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-16-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -25730,7 +25730,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -25751,7 +25751,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -25916,7 +25916,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-17-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-17-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -25938,7 +25938,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -25959,7 +25959,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -26124,7 +26124,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-18-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-18-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -26146,7 +26146,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -26167,7 +26167,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -26332,7 +26332,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-19-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-19-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -26354,7 +26354,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -26375,7 +26375,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -26540,7 +26540,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-20-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-20-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -26562,7 +26562,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -26583,7 +26583,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -26748,7 +26748,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-21-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-21-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -26770,7 +26770,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -26791,7 +26791,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -26956,7 +26956,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-22-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-22-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -26978,7 +26978,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -26999,7 +26999,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -27164,7 +27164,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-23-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-23-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -27186,7 +27186,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -27207,7 +27207,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -27372,7 +27372,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-24-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-24-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -27394,7 +27394,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -27415,7 +27415,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -27580,7 +27580,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-25-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-25-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -27602,7 +27602,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -27623,7 +27623,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -27788,7 +27788,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-26-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-26-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -27810,7 +27810,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -27831,7 +27831,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -27996,7 +27996,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-27-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-27-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -28018,7 +28018,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -28039,7 +28039,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -28204,7 +28204,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-28-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-28-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -28226,7 +28226,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -28247,7 +28247,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -28412,7 +28412,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-29-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-29-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -28434,7 +28434,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -28455,7 +28455,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -28620,7 +28620,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-UK-30-30-latest-mysql5.7-php7.2
+name: core-apiAll-enc-UK-30-30-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -28642,7 +28642,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -28663,7 +28663,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -28828,7 +28828,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-UK-3-1-latest-mysql5.7-php7.2
+name: core-cliAll-enc-UK-3-1-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -28850,7 +28850,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -28978,7 +28978,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-UK-3-2-latest-mysql5.7-php7.2
+name: core-cliAll-enc-UK-3-2-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29000,7 +29000,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29128,7 +29128,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-UK-3-3-latest-mysql5.7-php7.2
+name: core-cliAll-enc-UK-3-3-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29150,7 +29150,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29278,7 +29278,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-UK-5-1-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-UK-5-1-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29300,7 +29300,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29321,7 +29321,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -29501,7 +29501,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-UK-5-2-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-UK-5-2-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29523,7 +29523,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29544,7 +29544,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -29724,7 +29724,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-UK-5-3-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-UK-5-3-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29746,7 +29746,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29767,7 +29767,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -29947,7 +29947,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-UK-5-4-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-UK-5-4-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -29969,7 +29969,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -29990,7 +29990,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -30170,7 +30170,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-UK-5-5-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-UK-5-5-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -30192,7 +30192,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -30213,7 +30213,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -30393,7 +30393,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-1-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-1-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -30415,7 +30415,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -30436,7 +30436,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -30601,7 +30601,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-2-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-2-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -30623,7 +30623,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -30644,7 +30644,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -30809,7 +30809,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-3-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-3-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -30831,7 +30831,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -30852,7 +30852,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -31017,7 +31017,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-4-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-4-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -31039,7 +31039,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -31060,7 +31060,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -31225,7 +31225,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-5-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-5-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -31247,7 +31247,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -31268,7 +31268,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -31433,7 +31433,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-6-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-6-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -31455,7 +31455,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -31476,7 +31476,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -31641,7 +31641,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-7-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-7-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -31663,7 +31663,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -31684,7 +31684,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -31849,7 +31849,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-8-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-8-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -31871,7 +31871,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -31892,7 +31892,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -32057,7 +32057,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-9-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-9-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -32079,7 +32079,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -32100,7 +32100,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -32265,7 +32265,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-10-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-10-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -32287,7 +32287,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -32308,7 +32308,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -32473,7 +32473,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-11-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-11-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -32495,7 +32495,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -32516,7 +32516,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -32681,7 +32681,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-12-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-12-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -32703,7 +32703,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -32724,7 +32724,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -32889,7 +32889,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-13-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-13-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -32911,7 +32911,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -32932,7 +32932,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -33097,7 +33097,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-14-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-14-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -33119,7 +33119,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -33140,7 +33140,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -33305,7 +33305,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-15-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-15-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -33327,7 +33327,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -33348,7 +33348,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -33513,7 +33513,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-16-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-16-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -33535,7 +33535,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -33556,7 +33556,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -33721,7 +33721,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-17-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-17-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -33743,7 +33743,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -33764,7 +33764,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -33929,7 +33929,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-18-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-18-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -33951,7 +33951,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -33972,7 +33972,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -34137,7 +34137,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-19-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-19-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -34159,7 +34159,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -34180,7 +34180,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -34345,7 +34345,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-20-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-20-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -34367,7 +34367,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -34388,7 +34388,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -34553,7 +34553,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-21-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-21-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -34575,7 +34575,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -34596,7 +34596,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -34761,7 +34761,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-22-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-22-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -34783,7 +34783,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -34804,7 +34804,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -34969,7 +34969,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-23-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-23-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -34991,7 +34991,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -35012,7 +35012,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -35177,7 +35177,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-24-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-24-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -35199,7 +35199,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -35220,7 +35220,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -35385,7 +35385,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-25-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-25-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -35407,7 +35407,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -35428,7 +35428,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -35593,7 +35593,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-26-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-26-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -35615,7 +35615,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -35636,7 +35636,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -35801,7 +35801,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-27-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-27-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -35823,7 +35823,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -35844,7 +35844,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -36009,7 +36009,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-28-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-28-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36031,7 +36031,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -36052,7 +36052,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -36217,7 +36217,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-29-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-29-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36239,7 +36239,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -36260,7 +36260,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -36425,7 +36425,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-apiAll-enc-MK-30-30-latest-mysql5.7-php7.2
+name: core-apiAll-enc-MK-30-30-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36447,7 +36447,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -36468,7 +36468,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -36633,7 +36633,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-MK-3-1-latest-mysql5.7-php7.2
+name: core-cliAll-enc-MK-3-1-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36655,7 +36655,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -36783,7 +36783,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-MK-3-2-latest-mysql5.7-php7.2
+name: core-cliAll-enc-MK-3-2-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36805,7 +36805,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -36933,7 +36933,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-cliAll-enc-MK-3-3-latest-mysql5.7-php7.2
+name: core-cliAll-enc-MK-3-3-master-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -36955,7 +36955,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -37083,7 +37083,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-MK-5-1-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-MK-5-1-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -37105,7 +37105,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -37126,7 +37126,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -37306,7 +37306,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-MK-5-2-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-MK-5-2-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -37328,7 +37328,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -37349,7 +37349,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -37529,7 +37529,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-MK-5-3-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-MK-5-3-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -37551,7 +37551,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -37572,7 +37572,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -37752,7 +37752,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-MK-5-4-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-MK-5-4-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -37774,7 +37774,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -37795,7 +37795,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -37975,7 +37975,7 @@ depends_on:
 ---
 kind: pipeline
 type: docker
-name: core-wUI-enc-MK-5-5-latest-chrome-mysql5.7-php7.2
+name: core-wUI-enc-MK-5-5-master-chrome-mysql5.7-php7.2
 
 platform:
   os: linux
@@ -37997,7 +37997,7 @@ steps:
     db_type: mysql
     db_username: owncloud
     exclude: apps/user_ldap
-    version: latest
+    version: daily-master-qa
 
 - name: install-testrunner
   pull: always
@@ -38018,7 +38018,7 @@ steps:
     db_password: owncloud
     db_type: mysql
     db_username: owncloud
-    version: latest
+    version: daily-master-qa
 
 - name: configure-federation
   pull: always
@@ -38363,81 +38363,81 @@ depends_on:
 - core-wUI-latest-5-3-latest-chrome-mysql5.7-php7.2
 - core-wUI-latest-5-4-latest-chrome-mysql5.7-php7.2
 - core-wUI-latest-5-5-latest-chrome-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-1-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-2-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-3-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-4-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-5-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-6-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-7-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-8-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-9-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-10-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-11-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-12-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-13-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-14-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-15-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-16-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-17-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-18-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-19-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-20-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-21-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-22-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-23-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-24-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-25-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-26-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-27-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-28-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-29-latest-mysql5.7-php7.2
-- core-apiAll-enc-UK-30-30-latest-mysql5.7-php7.2
-- core-cliAll-enc-UK-3-1-latest-mysql5.7-php7.2
-- core-cliAll-enc-UK-3-2-latest-mysql5.7-php7.2
-- core-cliAll-enc-UK-3-3-latest-mysql5.7-php7.2
-- core-wUI-enc-UK-5-1-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-UK-5-2-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-UK-5-3-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-UK-5-4-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-UK-5-5-latest-chrome-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-1-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-2-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-3-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-4-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-5-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-6-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-7-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-8-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-9-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-10-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-11-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-12-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-13-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-14-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-15-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-16-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-17-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-18-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-19-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-20-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-21-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-22-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-23-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-24-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-25-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-26-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-27-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-28-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-29-latest-mysql5.7-php7.2
-- core-apiAll-enc-MK-30-30-latest-mysql5.7-php7.2
-- core-cliAll-enc-MK-3-1-latest-mysql5.7-php7.2
-- core-cliAll-enc-MK-3-2-latest-mysql5.7-php7.2
-- core-cliAll-enc-MK-3-3-latest-mysql5.7-php7.2
-- core-wUI-enc-MK-5-1-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-MK-5-2-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-MK-5-3-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-MK-5-4-latest-chrome-mysql5.7-php7.2
-- core-wUI-enc-MK-5-5-latest-chrome-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-1-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-2-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-3-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-4-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-5-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-6-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-7-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-8-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-9-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-10-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-11-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-12-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-13-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-14-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-15-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-16-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-17-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-18-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-19-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-20-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-21-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-22-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-23-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-24-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-25-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-26-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-27-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-28-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-29-master-mysql5.7-php7.2
+- core-apiAll-enc-UK-30-30-master-mysql5.7-php7.2
+- core-cliAll-enc-UK-3-1-master-mysql5.7-php7.2
+- core-cliAll-enc-UK-3-2-master-mysql5.7-php7.2
+- core-cliAll-enc-UK-3-3-master-mysql5.7-php7.2
+- core-wUI-enc-UK-5-1-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-UK-5-2-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-UK-5-3-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-UK-5-4-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-UK-5-5-master-chrome-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-1-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-2-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-3-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-4-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-5-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-6-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-7-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-8-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-9-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-10-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-11-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-12-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-13-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-14-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-15-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-16-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-17-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-18-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-19-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-20-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-21-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-22-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-23-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-24-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-25-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-26-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-27-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-28-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-29-master-mysql5.7-php7.2
+- core-apiAll-enc-MK-30-30-master-mysql5.7-php7.2
+- core-cliAll-enc-MK-3-1-master-mysql5.7-php7.2
+- core-cliAll-enc-MK-3-2-master-mysql5.7-php7.2
+- core-cliAll-enc-MK-3-3-master-mysql5.7-php7.2
+- core-wUI-enc-MK-5-1-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-MK-5-2-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-MK-5-3-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-MK-5-4-master-chrome-mysql5.7-php7.2
+- core-wUI-enc-MK-5-5-master-chrome-mysql5.7-php7.2
 
 ...


### PR DESCRIPTION
Fixes issue #616 

The nightly needs to be run against `daily-master-qa` because some changes in encryption depend on core changes that are only in core master.