### PR TITLE
Security: filter special characters from password field

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -187,6 +187,7 @@ class Configuration {
 			$setMethod = 'setValue';
 			switch ($key) {
 				case 'ldapAgentPassword':
+					$val = \filter_var($val, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW);
 					$setMethod = 'setRawValue';
 					break;
 				case 'homeFolderNamingRule':


### PR DESCRIPTION
Filter special characters like `\r\n` to prevent Server Side Request Forgery (SSRF) attacks.