### PR TITLE
Only set USER_PREFKEY_FIRSTLOGIN to '1' on first login

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -450,12 +450,18 @@ class Manager {
 	 * @param string $uid
 	 */
 	public function markLogin($uid) {
-		$this->ocConfig->setUserValue(
+		if ($this->ocConfig->getUserValue(
 			$uid,
 			'user_ldap',
-			self::USER_PREFKEY_FIRSTLOGIN,
-			1
-		);
+			self::USER_PREFKEY_FIRSTLOGIN
+		) !== '1') {
+			$this->ocConfig->setUserValue(
+				$uid,
+				'user_ldap',
+				self::USER_PREFKEY_FIRSTLOGIN,
+				'1'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
This prevents firstLoginAccomplished log entries get written each time as a user logs in under certain circumstances (log level...).