### PR TITLE
Just strip "low" chars, but don't do anything else

### DIFF
--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -187,7 +187,7 @@ class Configuration {
 			$setMethod = 'setValue';
 			switch ($key) {
 				case 'ldapAgentPassword':
-					$val = \filter_var($val, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW);
+					$val = \filter_var($val, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW);
 					$setMethod = 'setRawValue';
 					break;
 				case 'homeFolderNamingRule':


### PR DESCRIPTION
For testing purposes:
```
// $b contains all ascii chars from 0-255
php > var_dump(filter_var($b, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW));
string(229) " !&#34;#$%&&#39;()*+,-./0123456789:;?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~��������������������������������������������������������������������������������������������������������������������������������"
php > var_dump(filter_var($b, FILTER_UNSAFE_RAW, FILTER_FLAG_STRIP_LOW));
string(224) " !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~��������������������������������������������������������������������������������������������������������������������������������"
```