### PR TITLE
[tests-only] [full-ci] Adjust acceptance test steps that changed in core PR 39027

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -1849,7 +1849,7 @@ def acceptance(ctx):
 						(installFederated(testConfig['server'], testConfig['phpVersion'], testConfig['logLevel'], testConfig['database'], federationDbSuffix) + owncloudLog('federated') if testConfig['federatedServerNeeded'] else []) +
 						installApp(ctx, testConfig['phpVersion']) +
 						installExtraApps(testConfig['phpVersion'], testConfig['extraApps']) +
-						setupServerAndApp(ctx, testConfig['phpVersion'], testConfig['logLevel']) +
+						setupServerAndApp(ctx, testConfig['phpVersion'], testConfig['logLevel'], testConfig['federatedServerNeeded']) +
 						owncloudLog('server') +
 						setupCeph(testConfig['cephS3']) +
 						setupScality(testConfig['scalityS3']) +
@@ -2392,7 +2392,7 @@ def installApp(ctx, phpVersion):
 		]
 	}]
 
-def setupServerAndApp(ctx, phpVersion, logLevel):
+def setupServerAndApp(ctx, phpVersion, logLevel, federatedServerNeeded = False):
 	return [{
 		'name': 'setup-server-%s' % ctx.repo.name,
 		'image': 'owncloudci/php:%s' % phpVersion,
@@ -2405,6 +2405,7 @@ def setupServerAndApp(ctx, phpVersion, logLevel):
 			'php occ a:l',
 			'php occ config:system:set trusted_domains 1 --value=server',
 			'php occ log:manage --level %s' % logLevel,
+			'php occ config:system:set csrf.disabled --value=true' if federatedServerNeeded else ''
 		]
 	}]
 

--- a/tests/acceptance/features/webUIProvisioning/users.feature
+++ b/tests/acceptance/features/webUIProvisioning/users.feature
@@ -32,7 +32,7 @@ Feature: add users
     When the administrator changes the display name of user "new-user" to "New User" using the webUI
     And the administrator logs out of the webUI
     And user "new-user" logs in using the webUI
-    Then "New User" should be shown as the name of the current user on the WebUI
+    Then "New User" should be shown as the name of the current user on the webUI
     And user "new-user" should exist
     And the user attributes returned by the API should include
       | displayname | New User |
@@ -68,7 +68,7 @@ Feature: add users
     And the administrator changes the display name of user "Alice" to "New User" using the webUI
     And the administrator logs out of the webUI
     And user "Alice" logs in using the webUI
-    Then "ldap user" should be shown as the name of the current user on the WebUI
+    Then "ldap user" should be shown as the name of the current user on the webUI
     And user "Alice" should exist
     And the user attributes returned by the API should include
       | displayname | ldap user |

--- a/tests/acceptance/features/webUIUserLDAP/avatar.feature
+++ b/tests/acceptance/features/webUIUserLDAP/avatar.feature
@@ -12,12 +12,12 @@ Feature: providing an avatar by LDAP
   Scenario: upload an avatar to the LDAP server
     When the administrator sets the ldap attribute "jpegPhoto" of the entry "uid=Alice,ou=TestUsers" to the content of the file "testavatar.jpg"
     And user "Alice" has logged in using the webUI
-    Then the display name should not be visible on the WebUI
-    And an avatar should be shown for the current user on the WebUI
+    Then the display name should not be visible on the webUI
+    And an avatar should be shown for the current user on the webUI
 
   Scenario: set the avatar on the LDAP server to an invalid string
     When the administrator sets the ldap attribute "jpegPhoto" of the entry "uid=Alice,ou=TestUsers" to "0"
     And user "Alice" has logged in using the webUI
-    Then the display name should be visible on the WebUI
-    And "Alice Hansen" should be shown as the name of the current user on the WebUI
-    And no avatar should be shown for the current user on the WebUI
+    Then the display name should be visible on the webUI
+    And "Alice Hansen" should be shown as the name of the current user on the webUI
+    And no avatar should be shown for the current user on the webUI

--- a/tests/acceptance/features/webUIUserLDAP/changingDisplayName.feature
+++ b/tests/acceptance/features/webUIUserLDAP/changingDisplayName.feature
@@ -11,7 +11,7 @@ Feature: changing display name
   Scenario Outline: change display name on the LDAP server
     Given the administrator sets the ldap attribute "displayname" of the entry "uid=Alice,ou=TestUsers" to "<new-displayname>"
     When user "Alice" logs in using the webUI
-    Then "<new-displayname>" should be shown as the name of the current user on the WebUI
+    Then "<new-displayname>" should be shown as the name of the current user on the webUI
     Examples:
       | new-displayname |
       | 999             |
@@ -22,12 +22,12 @@ Feature: changing display name
   Scenario: change display name on the LDAP server
     Given the administrator sets the ldap attribute "displayname" of the entry "uid=Alice,ou=TestUsers" to "0"
     When user "Alice" logs in using the webUI
-    Then "0" should be shown as the name of the current user on the WebUI
+    Then "0" should be shown as the name of the current user on the webUI
 
   Scenario: delete display name on the LDAP server
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator sets the ldap attribute "displayname" of the entry "uid=Alice,ou=TestUsers" to ""
     When user "Alice" logs in using the webUI
-    Then "Alice" should be shown as the name of the current user on the WebUI
+    Then "Alice" should be shown as the name of the current user on the webUI
     When the user re-logs in as "Brian" using the webUI
-    Then "Brian Murphy" should be shown as the name of the current user on the WebUI
+    Then "Brian Murphy" should be shown as the name of the current user on the webUI


### PR DESCRIPTION
core PR https://github.com/owncloud/core/pull/39027 made some acceptance test steps consistently say "on the webUI"

1) This PR adjusts them in user_ldap feature files.

Fixes CI  fails like https://drone.owncloud.com/owncloud/user_ldap/3351/58/12
"FeatureContext has missing steps. Define them with these snippets:..."

2) Same as https://github.com/owncloud/admin_audit/issues/377 - fix the drone starlark so that `savePublicShare.feature` passes. The same starlark code changes as in https://github.com/owncloud/admin_audit/pull/378