### PR TITLE
[0.15.3 branch] only set USER_PREFKEY_FIRSTLOGIN to '1' on first login

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -450,12 +450,18 @@ class Manager {
 	 * @param string $uid
 	 */
 	public function markLogin($uid) {
-		$this->ocConfig->setUserValue(
+		if ($this->ocConfig->getUserValue(
 			$uid,
 			'user_ldap',
-			self::USER_PREFKEY_FIRSTLOGIN,
-			1
-		);
+			self::USER_PREFKEY_FIRSTLOGIN
+		) !== '1') {
+			$this->ocConfig->setUserValue(
+				$uid,
+				'user_ldap',
+				self::USER_PREFKEY_FIRSTLOGIN,
+				'1'
+			);
+		}
 	}
 
 	/**


### PR DESCRIPTION
GitHub is reporting a conflict in PR #658 for file `lib/User/Manager.php`

That was changed in master by PR #652 

Maybe if we backport that to the `release-0.15.3` branch then the conflict will go away?

Note: PR #652 will not be in either release 0.15.3 or release 0.15.4 - this is just trying to get rid of the reported conflict so that we can merge PR #652 