### PR TITLE
do not skip user on OOBE

### DIFF
--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -489,6 +489,7 @@ class Manager {
 	 * @param integer $limit
 	 * @param integer $offset
 	 * @return string[] an array of all uids
+	 * @throws OutOfBoundsException
 	 */
 	public function getUsers($search = '', $limit = 10, $offset = 0) {
 		$search = $this->access->escapeFilterPart($search, true);
@@ -521,17 +522,12 @@ class Manager {
 		);
 		$ownCloudUserNames = [];
 		foreach ($ldap_users as $ldapEntry) {
-			try {
-				$userEntry = $this->getFromEntry($ldapEntry);
-				$this->logger->debug(
-					"Caching ldap entry for <{$ldapEntry['dn'][0]}>:".\json_encode($ldapEntry),
-					['app' => self::class]
-				);
-				$ownCloudUserNames[] = $userEntry->getOwnCloudUID();
-			} catch (\OutOfBoundsException $e) {
-				// tell the admin why we skip the user
-				$this->logger->logException($e, ['app' => self::class]);
-			}
+			$userEntry = $this->getFromEntry($ldapEntry);
+			$this->logger->debug(
+				"Caching ldap entry for <{$ldapEntry['dn'][0]}>:".\json_encode($ldapEntry),
+				['app' => self::class]
+			);
+			$ownCloudUserNames[] = $userEntry->getOwnCloudUID();
 		}
 
 		$this->logger->debug('getUsers: '.\count($ownCloudUserNames). ' Users found', ['app' => self::class]);


### PR DESCRIPTION
- [ ] add unit tests

related to https://github.com/owncloud/enterprise/issues/4686#issue-951464336 .

Before this change we silently skipped the user with collision mapping, and just adding exception in the log. However, this could have led to situation when administrator could misconfigure his instance and user sync successfully works on misconfigured instance

before:
![Zrzut ekranu 2021-08-17 o 10 55 26](https://user-images.githubusercontent.com/13368647/129695703-973f87d4-6241-434f-9b90-f86fc989f2d3.png)

after:
![Zrzut ekranu 2021-08-17 o 10 54 50](https://user-images.githubusercontent.com/13368647/129695718-a67ce878-bd0f-4d84-a3cb-5ea8bb8cd1a5.png)
