### PR TITLE
When checking memberof, apply the group filter after getting all groups

### DIFF
--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -221,8 +221,7 @@ class Group_LDAP implements \OCP\GroupInterface {
 		$seen[$dnGroup] = 1;
 		$members = $this->access->readAttribute(
 			$dnGroup,
-			$this->access->getConnection()->ldapGroupMemberAssocAttr,
-			$this->access->getConnection()->ldapGroupFilter
+			$this->access->getConnection()->ldapGroupMemberAssocAttr
 		);
 		if (\is_array($members)) {
 			foreach ($members as $memberDN) {

--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -261,8 +261,7 @@ class Group_LDAP implements \OCP\GroupInterface {
 		if (!\is_array($groups)) {
 			return [];
 		}
-		$groups = $this->access->groupsMatchFilter($groups);
-		$allGroups =  $groups;
+		$allGroups = $groups;
 		$nestedGroups = $this->access->getConnection()->ldapNestedGroups;
 		if (\intval($nestedGroups) === 1) {
 			foreach ($groups as $group) {
@@ -521,6 +520,7 @@ class Group_LDAP implements \OCP\GroupInterface {
 			&& \intval($this->access->getConnection()->useMemberOfToDetectMembership) === 1
 		) {
 			$groupDNs = $this->_getGroupDNsFromMemberOf($userDN);
+			$groupDNs = $this->access->groupsMatchFilter($groupDNs);
 			if (\is_array($groupDNs)) {
 				foreach ($groupDNs as $dn) {
 					$groupName = $this->access->dn2groupname($dn);

--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -518,8 +518,9 @@ class Group_LDAP implements \OCP\GroupInterface {
 		if (\intval($this->access->getConnection()->hasMemberOfFilterSupport) === 1
 			&& \intval($this->access->getConnection()->useMemberOfToDetectMembership) === 1
 		) {
-			$groupDNs = $this->_getGroupDNsFromMemberOf($userDN);
-			$groupDNs = $this->access->groupsMatchFilter($groupDNs);
+			$groupDNs = $this->access->groupsMatchFilter(
+				$this->_getGroupDNsFromMemberOf($userDN)
+			);
 			if (\is_array($groupDNs)) {
 				foreach ($groupDNs as $dn) {
 					$groupName = $this->access->dn2groupname($dn);

--- a/tests/unit/Group_LDAPTest.php
+++ b/tests/unit/Group_LDAPTest.php
@@ -396,7 +396,7 @@ class Group_LDAPTest extends \Test\TestCase {
 			->method('dn2groupname')
 			->will($this->returnArgument(0));
 
-		$this->access->expects($this->exactly(3))
+		$this->access->expects($this->once())
 			->method('groupsMatchFilter')
 			->will($this->returnArgument(0));
 


### PR DESCRIPTION
For nested groups, this was a problem because the group filter could
remove the nested group, so we couldn't check the memberof attribute of
the nested group and we couldn't go upwards in the group tree.

GroupA contains GroupB, and GroupB contains User1. If the group filter
contains just GroupA (not GroupB), checking the "memberof" of User1
would return no group. This PR fixes this by returning GroupA, which is
part of the group filter (if the "nested groups" checkbox is active)

----

Related to https://github.com/owncloud/enterprise/issues/4754

### Steps to reproduce
1. In the AD create GroupA; inside GroupA create GroupB; inside GroupB create some users
2. Ensure the AD has additional users and groups
3. Configure the user_ldap app to connect to the AD
    1. User filter is something like `(&(|(objectclass=user))(|(|(memberof:1.2.840.113556.1.4.1941:=CN=GroupA,CN=Users,DC=forest,DC=dungeon,DC=prv)(primaryGroupID=2048))))` Basically, only members of the GroupA will be allowed. Note the `1.2.840.113556.1.4.1941` for the recursive search in AD.
    2. Login filter is the same, with the samaccountname as uid: `(&(&(|(objectclass=user))(|(|(memberof:1.2.840.113556.1.4.1941:=CN=GroupA,CN=Users,DC=forest,DC=dungeon,DC=prv)(primaryGroupID=2048))))(samaccoutname=%uid))`
    3. Group filter just takes into account the GroupA: `(&(|(objectclass=group))(|(|(cn=GroupA))))`
    4. Group-member association in the advanced tab must be "member (AD)"
    5. Nested groups checkbox must be enabled
    6. The rest of the option could be the default ones.
 4. Go to the users page

### Previous behavior
* Users inside the GroupB don't appear as member of GroupA. The'll likely appear without any group membership if they don't belong to any other group.
* Clicking in the GroupA (which should appear in the left sidebar) doesn't show any user

### PR's behavior
* Users inside GroupB appear ONLY as member of groupA. Note that GroupB isn't part of the "accepted" groups in the group filter, so this is ok.
* Clicking inside the GroupA shows all the users that are inside that group and any other group that is inside GroupA, such as GroupB. The users are shown only as members of the GroupA, not GroupB.