### PR TITLE
[tests-only] [full-ci] Update CI .drone.star and Makefile

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2502,7 +2502,7 @@ def installApp(ctx, phpVersion):
     else:
         installJsDeps = config["buildJsDeps"]
 
-    return [
+    return ([
         {
             "name": "install-app-js-%s" % config["app"],
             "image": "owncloudci/nodejs:%s" % getNodeJsVersion(),
@@ -2513,7 +2513,7 @@ def installApp(ctx, phpVersion):
                 "make build-dev",
             ],
         },
-    ] if installJsDeps else [] + [{
+    ] if installJsDeps else []) + [{
         "name": "install-app-%s" % ctx.repo.name,
         "image": "owncloudci/php:%s" % phpVersion,
         "pull": "always",

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,7 @@
 SHELL := /bin/bash
 
 COMPOSER_BIN := $(shell command -v composer 2> /dev/null)
-ifndef COMPOSER_BIN
-    $(error composer is not available on your system, please install composer)
-endif
-
-#
-# Define NPM and check if it is available on the system.
-#
 NPM := $(shell command -v npm 2> /dev/null)
-ifndef NPM
-    $(error npm is not available on your system, please install npm)
-endif
 
 NODE_PREFIX=$(shell pwd)
 


### PR DESCRIPTION
The latest changes to the `owncloudci/php` image have removed node, npm and yarn. So checks for those (and composer) in `Makefile` are removed here because, depending on the make target, some of the tools may not be needed, and depending on the docker image used in CI, some of the tools may not exist.