### PR TITLE
[tests-only] [full-ci] Adjust test scenarios that try to add a user to an LDAP group

### DIFF
--- a/tests/acceptance/features/webUIProvisioning/groups.feature
+++ b/tests/acceptance/features/webUIProvisioning/groups.feature
@@ -70,9 +70,9 @@ Feature: add group
   Scenario: Adding database user to LDAP group should not be possible
     Given user "db-user" has been created with default attributes in the database user backend
     And the administrator has browsed to the users page
-    When the administrator adds user "db-user" to group "grp1" using the webUI
+    When the administrator tries to add user "db-user" to group "grp1" using the webUI
     Then user "db-user" should exist
-    And user "db-user" should not belong to group "grp1"
+    But user "db-user" should not belong to group "grp1"
 
   Scenario: Adding LDAP user to database group should be possible
     Given group "db-group" has been created in the database user backend
@@ -84,6 +84,6 @@ Feature: add group
   @issue-core-25224
   Scenario: Adding LDAP user to LDAP group should not be possible
     Given the administrator has browsed to the users page
-    When the administrator adds user "Alice" to group "grp1" using the webUI
+    When the administrator tries to add user "Alice" to group "grp1" using the webUI
     Then user "Alice" should exist
-    And user "Alice" should not belong to group "grp1"
+    But user "Alice" should not belong to group "grp1"


### PR DESCRIPTION
Core PR https://github.com/owncloud/core/pull/39305 added the test step:
```
When the administrator tries to add user "xxx" to group "yyy" using the webUI
```

This step allows us to test trying to add a user to an LDAP group, when we expect that it should not be possible. This PR makes use of the test step.

Previously the User Management UI "went through the motions" of adding a user to an LDAP group, but actually the action did not really happen on the server. Since core PR https://github.com/owncloud/core/pull/39262 the core user management UI no longer actually lets the user be added to an LDAP group. user_ldap CI has been failing:

```
runsh: Total unexpected failed scenarios throughout the test run:
webUIProvisioning/groups.feature:70
webUIProvisioning/groups.feature:85


  Scenario: Adding database user to LDAP group should not be possible                          # /var/www/owncloud/testrunner/apps/user_ldap/tests/acceptance/features/webUIProvisioning/groups.feature:70
    Given user "db-user" has been created with default attributes in the database user backend # FeatureContext::userHasBeenCreatedOnDatabaseBackend()
    And the administrator has browsed to the users page                                        # WebUIUsersContext::theUserBrowsesToTheUsersPage()
    When the administrator adds user "db-user" to group "grp1" using the webUI                 # WebUIUsersContext::addsUserToGroupUsingTheWebui()
      Page\UsersPage::addOrRemoveUserToGroup xpath .//ul[@class='multiselectoptions down']/li/label[@title='%s'] could not find groups input for user db-user (SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException)
    Then user "db-user" should exist                                                           # FeatureContext::userShouldExist()
    And user "db-user" should not belong to group "grp1"                                       # FeatureContext::userShouldNotBelongToGroup()
SCENARIO RESULT: (fail)



  Scenario: Adding LDAP user to LDAP group should not be possible            # /var/www/owncloud/testrunner/apps/user_ldap/tests/acceptance/features/webUIProvisioning/groups.feature:85
    Given the administrator has browsed to the users page                    # WebUIUsersContext::theUserBrowsesToTheUsersPage()
    When the administrator adds user "Alice" to group "grp1" using the webUI # WebUIUsersContext::addsUserToGroupUsingTheWebui()
      Page\UsersPage::addOrRemoveUserToGroup xpath .//ul[@class='multiselectoptions down']/li/label[@title='%s'] could not find groups input for user Alice (SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException)
    Then user "Alice" should exist                                           # FeatureContext::userShouldExist()
    And user "Alice" should not belong to group "grp1"                       # FeatureContext::userShouldNotBelongToGroup()
SCENARIO RESULT: (fail)
```

The new test logic allows these scenarios to pass.