### PR TITLE
[tests-only] [full-ci] Bump tests to phpunit9

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -20,12 +20,12 @@ config = {
     "phpunit": {
         "allDatabases": {
             "phpVersions": [
-                "7.3",
+                "7.4",
             ],
         },
         "reducedDatabases": {
             "phpVersions": [
-                "7.4",
+                "7.3",
             ],
             "databases": [
                 "mysql:8.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,24 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<phpunit bootstrap="../../tests/bootstrap.php"
-		 verbose="true"
-		 failOnRisky="true"
-		 failOnWarning="true"
-		 timeoutForSmallTests="900"
-		 timeoutForMediumTests="900"
-		 timeoutForLargeTests="900"
-		>
-	<testsuites>
-		<testsuite name='unit'>
-			<directory suffix="Test.php">tests/unit</directory>
-		</testsuite>
-	</testsuites>
-	<!-- filters for code coverage -->
-	<filter>
-		<whitelist>
-			<directory suffix=".php">lib</directory>
-			<exclude>
-				<directory suffix=".php">l10n</directory>
-				<directory suffix=".php">tests</directory>
-			</exclude>
-		</whitelist>
-	</filter>
-	<logging>
-		<!-- and this is where your report will be written -->
-		<log type="coverage-clover" target="tests/output/clover.xml"/>
-	</logging>
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="../../tests/bootstrap.php" verbose="true" failOnRisky="true" failOnWarning="true" timeoutForSmallTests="900" timeoutForMediumTests="900" timeoutForLargeTests="900" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">lib</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">l10n</directory>
+      <directory suffix=".php">tests</directory>
+    </exclude>
+    <report>
+      <clover outputFile="tests/output/clover.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="unit">
+      <directory suffix="Test.php">tests/unit</directory>
+    </testsuite>
+  </testsuites>
+  <!-- filters for code coverage -->
+  <logging>
+    <!-- and this is where your report will be written -->
+  </logging>
 </phpunit>
-

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -29,5 +29,5 @@ sonar.pullrequest.branch=${env.SONAR_PULL_REQUEST_BRANCH}
 sonar.pullrequest.key=${env.SONAR_PULL_REQUEST_KEY}
 
 # Properties specific to language plugins:
-sonar.php.coverage.reportPaths=results/clover-phpunit-php7.3-mariadb10.2.xml,results/clover-phpunit-php7.3-mysql8.0.xml,results/clover-phpunit-php7.3-postgres9.4.xml,results/clover-phpunit-php7.3-oracle.xml,results/clover-phpunit-php7.3-sqlite.xml
+sonar.php.coverage.reportPaths=results/clover-phpunit-php7.4-mariadb10.2.xml,results/clover-phpunit-php7.4-mysql8.0.xml,results/clover-phpunit-php7.4-postgres9.4.xml,results/clover-phpunit-php7.4-oracle.xml,results/clover-phpunit-php7.4-sqlite.xml
 sonar.javascript.lcov.reportPaths=results/lcov.info

--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -18,6 +18,6 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
-        "phpunit/phpunit": "^8.5"
+        "phpunit/phpunit": "^9.5"
     }
 }


### PR DESCRIPTION
1) switch to using PHP 7.4 for PHP unit tests with coverage (there is sometimes a problem generating coverage with PHPunit9 and PHP 7.3 and something in our combinations of dependencies... - we can easily avoid that, PHP 7.3 is about to end security support anyway...)

2) Migrate `phpunit.xml` with the command:
`../../lib/composer/bin/phpunit --migrate-configuration`

3) use phpunit 9 in acceptance test dependencies. That will fix failures running core tests like:
https://drone.owncloud.com/owncloud/user_ldap/3512/79/17
```
Fatal error: Call to undefined method PHPUnit\Framework\Assert::assertMatchesRegularExpression() (Behat\Testwork\Call\Exception\FatalThrowableError)
```
