### PR TITLE
[tests-only] skip dbConversion tests

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -419,7 +419,7 @@ config = {
             "runAllSuites": True,
             "numberOfParts": 2,
             "emailNeeded": True,
-            "filterTags": "~@skip&&~@app-required",
+            "filterTags": "~@skip&&~@app-required&&~@dbConversion",
         },
         "core-cli-acceptance-latest-nightly": {
             "suites": {
@@ -438,7 +438,7 @@ config = {
             "runAllSuites": True,
             "numberOfParts": 2,
             "emailNeeded": True,
-            "filterTags": "~@skip&&~@app-required",
+            "filterTags": "~@skip&&~@app-required&&~@dbConversion",
             "cron": "nightly",
         },
         "core-webui-acceptance": {
@@ -627,7 +627,7 @@ config = {
             "extraApps": {
                 "encryption": "",
             },
-            "filterTags": "~@skipOnEncryption&&~@skipOnEncryptionType:user-keys&&~@skip&&~@app-required",
+            "filterTags": "~@skipOnEncryption&&~@skipOnEncryptionType:user-keys&&~@skip&&~@app-required&&~@dbConversion",
             "extraSetup": [
                 {
                     "name": "configure-app",
@@ -806,7 +806,7 @@ config = {
             "extraApps": {
                 "encryption": "",
             },
-            "filterTags": "~@skipOnEncryption&&~@skipOnEncryptionType:masterkey&&~@skip&&~@app-required",
+            "filterTags": "~@skipOnEncryption&&~@skipOnEncryptionType:masterkey&&~@skip&&~@app-required&&~@dbConversion",
             "extraSetup": [
                 {
                     "name": "configure-app",


### PR DESCRIPTION
Those need special setup, which is done in core. We don't need to run those in app test pipelines.