### PR TITLE
Test against core latest

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -101,7 +101,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -117,7 +117,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -181,7 +181,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -196,7 +196,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -263,7 +263,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -279,7 +279,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -360,7 +360,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -429,7 +429,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -499,7 +499,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -550,7 +550,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -614,7 +614,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -664,7 +664,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -729,7 +729,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -793,7 +793,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",
@@ -843,7 +843,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC2",
+                "10.9.1RC1",
             ],
             "phpVersions": [
                 "7.3",

--- a/.drone.star
+++ b/.drone.star
@@ -101,7 +101,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -117,7 +117,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -181,7 +181,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -196,7 +196,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -263,7 +263,7 @@ config = {
                 "oracle",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -279,7 +279,7 @@ config = {
             ],
             "servers": [
                 "daily-master-qa",
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -360,7 +360,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -429,7 +429,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -499,7 +499,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -550,7 +550,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -614,7 +614,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -664,7 +664,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -729,7 +729,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -793,7 +793,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",
@@ -843,7 +843,7 @@ config = {
                 "mysql:8.0",
             ],
             "servers": [
-                "10.9.1RC1",
+                "latest",
             ],
             "phpVersions": [
                 "7.3",


### PR DESCRIPTION
Part of issue https://github.com/owncloud/encryption/issues/317

I reverted the 3 commits from PRs #709 and #705  in reverse order:
```
$ git checkout -b test-against-core-latest
Switched to a new branch 'test-against-core-latest'
$ git revert 36247291dbff17cd6e4d989a04d2d0449f45b734
[test-against-core-latest adaeee05] Revert "Test against 10.9.1RC2"
 1 file changed, 15 insertions(+), 15 deletions(-)
$ git revert 5bbfe5bba825fb59fe60ae2b4d8102364cd2cfcb
Auto-merging .drone.star
[test-against-core-latest 24ee746a] Revert "Test against 10.9.1RC1"
 1 file changed, 15 insertions(+), 15 deletions(-)
```
