### PR TITLE
Decode binary guid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 - Change color of warning sign for expert settings [#678](https://github.com/owncloud/user_ldap/pull/678)
+- Decode binary GUID where we normally expected string (eDirectory) [#711](https://github.com/owncloud/user_ldap/pull/711)
 
 ## [0.15.4] - 2021-07-13
 

--- a/lib/Access.php
+++ b/lib/Access.php
@@ -1862,10 +1862,23 @@ class Access implements IUserTools {
 	 * {@link http://www.php.net/manual/en/function.ldap-get-values-len.php#73198 The PHP ldap_get_values_lan doc comments}
 	 *
 	 * @param string $binGuid the ObjectGUID / GUID in it's binary form as retrieved from Microsoft AD / Novell eDirectory
+	 *                        If you pass an already decoded GUID as string, it will be returned as is.
 	 * @return string
 	 * @throws \OutOfBoundsException
 	 */
 	public static function binGUID2str($binGuid) {
+		$guidLength = \strlen($binGuid);
+
+		// The guid should have 16 byte when binary and 36 byte when string (including '-' characters)
+		if (($guidLength !== 16) && ($guidLength !== 36)) {
+			throw new \OutOfBoundsException(\sprintf('Invalid GUID with length %d received: <%X>', $guidLength, $binGuid));
+		}
+
+		// If we get a guid in string form we simply return it to prevent double decoding
+		if ($guidLength === 36) {
+			return $binGuid;
+		}
+
 		// V = unsigned long (always 32 bit, little endian byte order)
 		// v = unsigned short (always 16 bit, little endian byte order)
 		// n = unsigned short (always 16 bit, big endian byte order)

--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -365,6 +365,11 @@ class UserEntry {
 			if ($trim) {
 				$value = \trim($value);
 			}
+
+			if ($attributeName === 'objectguid' || $attributeName === 'guid') {
+				$value = Access::binGUID2str($value);
+			}
+
 			if ($value === '') {
 				return $default;
 			}

--- a/tests/unit/User/UserEntryTest.php
+++ b/tests/unit/User/UserEntryTest.php
@@ -247,7 +247,7 @@ class UserEntryTest extends \Test\TestCase {
 	public function testGetUUIDInvalidBinaryUUID() {
 		$this->expectException(\OutOfBoundsException::class);
 
-		$this->connection->expects($this->exactly(2))
+		$this->connection->expects($this->exactly(1))
 			->method('__get')
 			->with($this->equalTo('ldapExpertUUIDUserAttr'))
 			->will($this->returnValue('objectguid'));


### PR DESCRIPTION
With Oracle eDirectory we sometimes get a GUID as binaray where our code would normally expect a string.

https://github.com/owncloud/enterprise/issues/4686

- [x] Unit-Tests