### PR TITLE
[tests-only] Test member count of LDAP group on webUI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -320,7 +320,7 @@ config = {
             "federatedServerNeeded": True,
             "filterTags": "~@skip&&~@app-required",
             "runAllSuites": True,
-            "numberOfParts": 21,
+            "numberOfParts": 30,
             "extraSetup": [
                 {
                     "name": "configure-app",

--- a/tests/acceptance/features/webUIProvisioning/groups.feature
+++ b/tests/acceptance/features/webUIProvisioning/groups.feature
@@ -18,6 +18,15 @@ Feature: add group
     And user admin has logged in using the webUI
     And the administrator has browsed to the users page
 
+  Scenario: An LDAP group should be listed but the member count is not known
+    Then the group name "grp1" should be listed on the webUI
+    And the user count of group "grp1" should display 0 users on the webUI
+    # there are 2 LDAP users in this LDAP group
+    # TBD if we can or should display that information
+    #And the user count of group "grp1" should display 2 users on the webUI
+    # or a step like this: (maybe there should be no count displayed for LDAP groups
+    #And the user count of group "grp1" should not be displayed on the webUI
+
   Scenario: Adding a simple database group should be possible
     When the administrator adds group "simple-group" using the webUI
     Then the group name "simple-group" should be listed on the webUI
@@ -65,6 +74,9 @@ Feature: add group
     When the administrator adds user "db-user" to group "db-group" using the webUI
     Then user "db-user" should exist
     And user "db-user" should belong to group "db-group"
+    And the user count of group "db-group" should display 0 users on the webUI
+    # for a database group and user, we should really see the user in the count
+    #And the user count of group "db-group" should display 1 users on the webUI
 
   @issue-core-25224
   Scenario: Adding database user to LDAP group should not be possible
@@ -80,6 +92,10 @@ Feature: add group
     When the administrator adds user "Alice" to group "db-group" using the webUI
     Then user "Alice" should exist
     And user "Alice" should belong to group "db-group"
+    And the user count of group "db-group" should display 0 users on the webUI
+    # for a database group and LDAP user, we should really see the user in the count
+    # The group and group membership is all on the server, not back in LDAP
+    #And the user count of group "db-group" should display 1 users on the webUI
 
   @issue-core-25224
   Scenario: Adding LDAP user to LDAP group should not be possible


### PR DESCRIPTION
Add tests to demonstrate the current behavior of the member count of LDAP groups on the User Management UI.

The member count is shown as zero.

Related issue: https://github.com/owncloud/enterprise/issues/4957

These tests can be a place for developers to start sorting this out - modify the tests to expect whatever is the required behavior, then get themj to pass.

The 2nd commit increases the number of pipelines for core-apiAll, in order to reduce the elapsed run-time. Issue #713 