### PR TITLE
[full-ci] Add composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,9 @@
     "config": {
         "platform": {
             "php": "7.3"
+        },
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
         }
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "bamarni/composer-bin-plugin",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
+                "reference": "f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e",
+                "reference": "f7fb03e96a154f9c7a10fe736b6c1fa4a617d54e",
                 "shasum": ""
             },
             "require": {
@@ -53,9 +53,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/1.4.2"
             },
-            "time": "2020-05-03T08:27:20+00:00"
+            "time": "2022-02-16T16:23:46+00:00"
         },
         {
             "name": "laminas/laminas-ldap",
@@ -137,5 +137,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/tests/acceptance/features/webUIProvisioning/groups.feature
+++ b/tests/acceptance/features/webUIProvisioning/groups.feature
@@ -18,14 +18,10 @@ Feature: add group
     And user admin has logged in using the webUI
     And the administrator has browsed to the users page
 
-  Scenario: An LDAP group should be listed but the member count is not known
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  Scenario: An LDAP group should be listed but the member count is not displayed
     Then the group name "grp1" should be listed on the webUI
-    And the user count of group "grp1" should display 0 users on the webUI
-    # there are 2 LDAP users in this LDAP group
-    # TBD if we can or should display that information
-    #And the user count of group "grp1" should display 2 users on the webUI
-    # or a step like this: (maybe there should be no count displayed for LDAP groups
-    #And the user count of group "grp1" should not be displayed on the webUI
+    And the user count of group "grp1" should not be displayed on the webUI
 
   Scenario: Adding a simple database group should be possible
     When the administrator adds group "simple-group" using the webUI
@@ -67,6 +63,7 @@ Feature: add group
       | Unable to delete grp1 | Unable to delete group. |
     And group "grp1" should exist
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Adding database user to database group should be possible
     Given user "db-user" has been created with default attributes in the database user backend
     And group "db-group" has been created in the database user backend
@@ -74,7 +71,7 @@ Feature: add group
     When the administrator adds user "db-user" to group "db-group" using the webUI
     Then user "db-user" should exist
     And user "db-user" should belong to group "db-group"
-    And the user count of group "db-group" should display 0 users on the webUI
+    And the user count of group "db-group" should not be displayed on the webUI
     # for a database group and user, we should really see the user in the count
     #And the user count of group "db-group" should display 1 users on the webUI
 
@@ -86,16 +83,14 @@ Feature: add group
     Then user "db-user" should exist
     But user "db-user" should not belong to group "grp1"
 
+  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario: Adding LDAP user to database group should be possible
     Given group "db-group" has been created in the database user backend
     And the administrator has browsed to the users page
     When the administrator adds user "Alice" to group "db-group" using the webUI
     Then user "Alice" should exist
     And user "Alice" should belong to group "db-group"
-    And the user count of group "db-group" should display 0 users on the webUI
-    # for a database group and LDAP user, we should really see the user in the count
-    # The group and group membership is all on the server, not back in LDAP
-    #And the user count of group "db-group" should display 1 users on the webUI
+    And the user count of group "db-group" should not be displayed on the webUI
 
   @issue-core-25224
   Scenario: Adding LDAP user to LDAP group should not be possible


### PR DESCRIPTION
### Description
This PR commits the `allow-plugins` section for `composer.json` so that it is there for anyone who updates to composer `2.2`.

The 2nd commit adjusts test scenarios for issue #716 - that gets all CI green.

### Related
Part of https://github.com/owncloud/QA/issues/723

Note: This PR is created with a script. If there is any unexpected case in it, I will update manually.
