### PR TITLE
Upgrading laminas/laminas-ldap (2.12.0 => 2.13.0)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -59,16 +59,16 @@
         },
         {
             "name": "laminas/laminas-ldap",
-            "version": "2.12.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-ldap.git",
-                "reference": "b07b8714363d5acb82af74efb9e96d5436e1b044"
+                "reference": "308f7749b12e2c14e91f51ddca4e2296fafe2367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-ldap/zipball/b07b8714363d5acb82af74efb9e96d5436e1b044",
-                "reference": "b07b8714363d5acb82af74efb9e96d5436e1b044",
+                "url": "https://api.github.com/repos/laminas/laminas-ldap/zipball/308f7749b12e2c14e91f51ddca4e2296fafe2367",
+                "reference": "308f7749b12e2c14e91f51ddca4e2296fafe2367",
                 "shasum": ""
             },
             "require": {
@@ -121,7 +121,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-12-03T12:08:21+00:00"
+            "time": "2022-03-19T15:18:53+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
drone is not starting in PR #726 

This is a replacement.