### PR TITLE
[tests-only] Save exitcode of last occ command

### DIFF
--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -138,8 +138,10 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function ldapUserIsSynced(string $user):void {
-		$this->featureContext->runOcc(
-			['user:sync', 'OCA\User_LDAP\User_Proxy', '-u', $user, '-m', 'remove']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['user:sync', 'OCA\User_LDAP\User_Proxy', '-u', $user, '-m', 'remove']
+			)
 		);
 		if ($this->featureContext->getExitStatusCodeOfOccCommand() !== 0) {
 			throw new \Exception(
@@ -156,7 +158,9 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdminListsTheEnabledBackendsUsingTheOccCommand():void {
-		$this->featureContext->runOcc(["user:sync -l"]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(["user:sync -l"])
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Description
The PR https://github.com/owncloud/core/pull/40359 has implemented different method to save the exitcode of the last occ command and the local tests were failing because the exitcode was not saved.
In this PR, I have implemented the updated way to save the occ exitCode.


## Related Issue
Fixes https://github.com/owncloud/user_ldap/issues/752
