### PR TITLE
Provide a command similar to the reuse_account flag to remap ldap users

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -42,6 +42,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 		<command>OCA\User_LDAP\Command\DeleteConfig</command>
 		<command>OCA\User_LDAP\Command\Search</command>
 		<command>OCA\User_LDAP\Command\CheckUser</command>
+		<command>OCA\User_LDAP\Command\RemapUser</command>
 		<command>OCA\User_LDAP\Command\InvalidateCache</command>
 	</commands>
 

--- a/lib/Command/RemapUser.php
+++ b/lib/Command/RemapUser.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022, ownCloud GmbH.
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\User_LDAP\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use OCA\User_LDAP\Mapping\UserMapping;
+use OCA\User_LDAP\Helper as LDAPHelper;
+use OCA\User_LDAP\User_Proxy;
+
+class RemapUser extends Command {
+	/** @var \OCA\User_LDAP\User_Proxy */
+	protected $backend;
+
+	/** @var \OCA\User_LDAP\Helper */
+	protected $helper;
+
+	/** @var \OCA\User_LDAP\Mapping\UserMapping */
+	protected $mapping;
+
+	/**
+	 * @param User_Proxy $uBackend
+	 * @param LDAPHelper $helper
+	 * @param UserMapping $mapping
+	 */
+	public function __construct(User_Proxy $uBackend, LDAPHelper $helper, UserMapping $mapping) {
+		$this->backend = $uBackend;
+		$this->helper = $helper;
+		$this->mapping = $mapping;
+		parent::__construct();
+	}
+
+	protected function configure() {
+		$this
+			->setName('ldap:remap-user')
+			->setDescription('checks whether a user exists on LDAP')
+			->addArgument(
+				'ocName',
+				InputArgument::REQUIRED,
+				'the user name as used in ownCloud'
+			)
+			->addOption(
+				'force',
+				null,
+				InputOption::VALUE_NONE,
+				'ignores disabled LDAP configuration'
+			)
+		;
+	}
+
+	/**
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int|void|null
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$uid = $input->getArgument('ocName');
+		$this->isAllowed($input->getOption('force'));
+		//$this->confirmUserIsMapped($uid);
+
+		$mappedData = $this->getMappedUUIDAndDN($uid);
+		if ($mappedData['mappedDN'] === false || $mappedData['mappedUUID'] === false) {
+			$output->writeln('User not mapped yet. Try to sync it with the user:sync command');
+			return -1;
+		}
+
+		$output->writeln('Mapped user found in the DB:');
+		$table1 = new Table($output);
+		$table1->setHeaders(['username', 'uuid', 'dn']);
+		$table1->addRow([$uid, $mappedData['mappedUUID'], $mappedData['mappedDN']]);
+		$table1->render();
+
+		$entries = $this->backend->findUsername($uid);
+		$entryCount = \count($entries);
+
+		$output->writeln('');
+		$output->writeln('Candidates found in LDAP:');
+		$table2 = new Table($output);
+		$table2->setHeaders(['username', 'uuid', 'dn']);
+		foreach ($entries as $entry) {
+			$table2->addRow([$entry['owncloud_name'], $entry['directory_uuid'], $entry['dn']]);
+		}
+		$table2->render();
+
+		if ($entryCount > 1) {
+			$output->writeln('<error>Found too many candidates in LDAP for the target user, remapping isn\'t possible</error>');
+			return 1;
+		} elseif ($entryCount < 1) {
+			$output->writeln('<error>User not found in LDAP. Consider removing the ownCloud\'s account</error>');
+			return 2;
+		}
+
+		if ($mappedData['mappedDN'] === $entries[0]['dn'] && $mappedData['mappedUUID'] === $entries[0]['directory_uuid']) {
+			$output->writeln('The same user is already mapped. Nothing to do');
+			return 0;  // just show a message and return a success code
+		}
+
+		$result = $this->mapping->replaceUUIDAndDN($uid, $entries[0]['dn'], $entries[0]['directory_uuid']);
+		if ($result === false) {
+			$output->writeln("<error>Failed to replace mapping data for user {$uid}</error>");
+			return 3;
+		}
+		$output->writeln('Mapping data replaced');
+	}
+
+	private function getMappedUUIDAndDN($username) {
+		$dn = $this->mapping->getDNByName($username);
+		$uuid = $this->mapping->getUUIDByName($username);
+		return [
+			'mappedDN' => $dn,
+			'mappedUUID' => $uuid,
+		];
+	}
+
+	/**
+	 * checks whether a user is actually mapped
+	 * @param string $ocName the username as used in ownCloud
+	 * @throws \Exception
+	 * @return true
+	 */
+	private function confirmUserIsMapped($ocName) {
+		$dn = $this->mapping->getDNByName($ocName);
+		if ($dn === false) {
+			throw new \Exception('The given user is not a recognized LDAP user.');
+		}
+
+		return true;
+	}
+
+	/**
+	 * checks whether the setup allows reliable checking of LDAP user existence
+	 * @throws \Exception
+	 * @return true
+	 */
+	private function isAllowed($force) {
+		if ($this->helper->haveDisabledConfigurations() && !$force) {
+			throw new \Exception('Cannot check user existence, because '
+				. 'disabled LDAP configurations are present.');
+		}
+
+		return true;
+	}
+}

--- a/lib/Mapping/AbstractMapping.php
+++ b/lib/Mapping/AbstractMapping.php
@@ -195,6 +195,15 @@ abstract class AbstractMapping {
 	}
 
 	/**
+	 * Gets the LDAP UUID based on the provided name.
+	 * @param string $name
+	 * @return string|false
+	 */
+	public function getUUIDByName($name) {
+		return $this->getXbyY('directory_uuid', 'owncloud_name', $name);
+	}
+
+	/**
 	 * gets a piece of the mapping list
 	 * TODO unused, remove
 	 * @param int $offset
@@ -251,6 +260,24 @@ abstract class AbstractMapping {
 			WHERE `owncloud_name` = ?');
 
 		return $this->modify($query, [$name]);
+	}
+
+	/**
+	 * Replace the dn and the uuid for the owncloud_name
+	 * @param string $name the owncloud_name
+	 * @param string $dn the new dn for the owncloud_name
+	 * @param string $uuid the new directory_uuid for the owncloud_name
+	 * @return int|false the number of row updated or false in case of error
+	 */
+	public function replaceUUIDAndDN($name, $dn, $uuid) {
+		$queryStr = "UPDATE `{$this->getTableName()}` SET `ldap_dn` = ?, `directory_uuid` = ? WHERE `owncloud_name` = ?";
+		$query = $this->dbc->prepare($queryStr);
+		$result = $query->execute([$dn, $uuid, $name]);
+		if ($result === true) {
+			return $query->rowCount();
+		} else {
+			return false;
+		}
 	}
 
 	/**

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -407,6 +407,10 @@ class User_LDAP implements IUserBackend, UserInterface {
 		return null;
 	}
 
+	public function findUsername($uid) {
+		return $this->userManager->findUsersByUsername($uid);
+	}
+
 	public function clearConnectionCache() {
 		$this->userManager->getConnection()->clearCache();
 	}

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -175,6 +175,18 @@ class User_Proxy extends Proxy implements
 		return $users;
 	}
 
+	public function findUsername($uid) {
+		// we do it just as the /OC_User implementation: do not play around with limit and offset but ask all backends
+		$users = [];
+		foreach ($this->backends as $backend) {
+			$backendUsers = $backend->findUsername($uid);
+			if (\is_array($backendUsers)) {
+				$users = \array_merge($users, $backendUsers);
+			}
+		}
+		return $users;
+	}
+
 	/**
 	 * check if a user exists
 	 * @param string $uid the username


### PR DESCRIPTION
Ref https://github.com/owncloud/enterprise/issues/5449

Allow remaping the LDAP user if it's the only one possible. This could happen if the LDAP user has been moved AND the directory_uuid has also changed, but the target username is the same.
The behavior should be similar than syncing the backend with the "reuse_account" flag, but in a more controlled way.

Note that this WON'T solve the collisions that could be happening. If 2 or more LDAP users could match the same username, the remap will be aborted.