### PR TITLE
Only trim on the string representation of an attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased] - 2022-xx-xx
 
+- [#770](https://github.com/owncloud/user_ldap/pull/770) - Don't trim binary attribute values as this might corrupt the value if it starts with a non-printable ASCII byte.
 
 ## [0.16.1] - 2022-11-07
 

--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -360,13 +360,14 @@ class UserEntry {
 		$attributeName = \strtolower($attributeName); // all ldap keys are lowercase
 		if (isset($this->ldapEntry[$attributeName][0])) {
 			$value = $this->ldapEntry[$attributeName][0];
-			if ($trim) {
-				$value = \trim($value);
-			}
 
 			$converterHub = ConverterHub::getDefaultConverterHub();
 			if ($converterHub->hasConverter($attributeName)) {
 				$value = $converterHub->bin2str($attributeName, $value);
+			}
+
+			if ($trim) {
+				$value = \trim($value);
 			}
 
 			if ($value === '') {


### PR DESCRIPTION
Trimming on binary could potentially remove control-characters which are actually part of the binary attribute value.