### PR TITLE
[full-ci] Fixup code reported by phpstan 1.10.1

### DIFF
--- a/lib/Access.php
+++ b/lib/Access.php
@@ -665,7 +665,6 @@ class Access implements IUserTools {
 		}
 		$groupBackend = $group->getBackend();
 		$groupBackendClass = \get_class($groupBackend);
-		/** @phpstan-ignore-next-line */
 		if (($groupBackendClass === \OCA\User_LDAP\Group_LDAP::class || $groupBackendClass === \OCA\User_LDAP\Group_Proxy::class)
 				&& \OC::$server->getConfig()->getAppValue('user_ldap', 'reuse_accounts', 'no') === 'yes') {
 			// Account with same groupname exists, and matching backend, we can use this - merge
@@ -2088,7 +2087,7 @@ class Access implements IUserTools {
 					if (!$pagedSearchOK) {
 						return false;
 					}
-				} else {  /** @phpstan-ignore-line */
+				} else {
 					\OC::$server->getLogger()->debug(
 						"No paged search for us at $range",
 						['app' => 'user_ldap']

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -160,7 +160,7 @@ class Manager {
 			$attributes[\substr($homeRule, \strlen('attr:'))] = true;
 		}
 		$searchAttributes = $ldapConfig->ldapAttributesForUserSearch;
-		if ($searchAttributes === '' || $searchAttributes === null) { /** @phpstan-ignore-line FIXME empty multiline initializes as '', make it [] */
+		if ($searchAttributes === '' || $searchAttributes === null) { /** FIXME empty multiline initializes as '', make it [] */
 			$searchAttributes = [];
 		}
 		foreach ($searchAttributes as $attr) {

--- a/lib/Wizard.php
+++ b/lib/Wizard.php
@@ -720,24 +720,6 @@ class Wizard extends LDAPUtility {
 	}
 
 	/**
-	 * Checks, whether a port was entered in the Host configuration
-	 * field. In this case the port will be stripped off, but also stored as
-	 * setting.
-	 */
-	private function checkHost() {
-		$host = $this->configuration->ldapHost;
-		$hostInfo = \parse_url($host);
-
-		//removes Port from Host
-		if (\is_array($hostInfo) && isset($hostInfo['port'])) {
-			$port = $hostInfo['port'];
-			$host = \str_replace(':'.$port, '', $host);
-			$this->applyFind('ldap_host', $host);
-			$this->applyFind('ldap_port', (string)$port);
-		}
-	}
-
-	/**
 	 * tries to detect the group member association attribute which is
 	 * one of 'uniqueMember', 'memberUid', 'member'
 	 * @return string|false, string with the attribute name, false on error

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,5 +17,5 @@ parameters:
       message: '#^Dead catch [^"]* is never thrown in the try block.$#'
       path: lib/Access.php
     -
-      message: "#Strict comparison using === between non-falsy-string and '' will always evaluate to false.#"
+      message: "#Strict comparison using === between mixed and '' will always evaluate to false.#"
       path: lib/Wizard.php


### PR DESCRIPTION
Fixes #777 

Some things have improved in phpstan.

Removed `phpstan-ignore-line` in a few places - those things are no longer reported as false positives - good.

Removed unused `checkHost()` function (phpstan noticed that this is unused)

The text of one of the ignored errors changed.