### PR TITLE
[tests-only][full-ci]Reverted the selction for encription type master-key

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -537,6 +537,7 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
+                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },
@@ -585,6 +586,7 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
+                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },
@@ -647,6 +649,7 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
+                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },


### PR DESCRIPTION
### Description
For latest stable oc10 we still require the selection of the `encryption type masterkey`. since this was removed from the https://github.com/owncloud/user_ldap/commit/e9c3f1048ef02320759fbf205e1c0835ecc89dfd this PR. This PR reverts only the command to section type of encryption in latest nightly run with user_ldap and encryption.

***NOTE:This might fail when the master becomes the latest and at that time we can remove the selection of the encryption-type.***

More details can be found here:
https://github.com/owncloud/encryption/issues/393#issuecomment-1493280016.

### Related Issue:
https://github.com/owncloud/user_ldap/issues/780