### PR TITLE
Add condition in `doConnect` for checking network timeout is set

### DIFF
--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -672,7 +672,8 @@ class Connection extends LDAPUtility {
 		} else {
 			throw new ServerNotAvailableException('Could not set required LDAP Protocol version.');
 		}
-		// Set network timeout threshold to avoid long delays when ldap server cannot be resolved
+		// Set network timeout threshold to avoid long delays when ldap server cannot be resolved.
+		// Check if the network timeout is set otherwhise this would silently fail making the connection unhealthy.
 		if ($this->configuration->ldapNetworkTimeout) {
 			$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_NETWORK_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));
 			$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -673,8 +673,10 @@ class Connection extends LDAPUtility {
 			throw new ServerNotAvailableException('Could not set required LDAP Protocol version.');
 		}
 		// Set network timeout threshold to avoid long delays when ldap server cannot be resolved
-		$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_NETWORK_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));
-		$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));
+		if ($this->configuration->ldapNetworkTimeout) {
+			$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_NETWORK_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));
+			$this->getLDAP()->setOption($this->ldapConnectionRes, (string)LDAP_OPT_TIMEOUT, \intval($this->configuration->ldapNetworkTimeout));
+		}
 		if (!$this->getLDAP()->isResource($this->ldapConnectionRes)) {
 			$this->ldapConnectionRes = null; // to indicate it really is not set, connect() might have set it to false
 			throw new ServerNotAvailableException("Connect to $host:$port failed");


### PR DESCRIPTION
## Description
Add condition in `doConnect` for verifying network timeout is set.

## Motivation and Context

Removing the `Network Timeout` value in the Advanced tab of the LDAP wizard is breaking the LDAP configuration with no hints whatsoever of what is wrong. There is no check in place in the WebUI to force the use of this option so we should add a condition to check if this is set when calling `doConnect`.

## How Has This Been Tested?
Manually by removing the `Network Timeout` value in the Advanced tab of the LDAP wizard and checking the LDAP configuration is still healthy.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item