### PR TITLE
Fix typo in comment. Make it less confusing

### DIFF
--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -1009,7 +1009,7 @@ class Group_LDAP implements \OCP\GroupInterface {
 	 * missing group)
 	 * @param string $gid the gid of the group we want to get the details of
 	 * @return array|null an array containing the gid and the displayname such as
-	 * ['gid' => 'abcdef', 'displayname' => 'my group']
+	 * ['gid' => 'abcdef', 'displayName' => 'my group']
 	 */
 	public function getGroupDetails($gid) {
 		$cacheKey = "groupDetails-$gid";


### PR DESCRIPTION
Fix typo in the comments. The actual key is "displayName"; using "displayname" (full lowercase) won't work properly and the displayname would be ignored.

There is no change in the code since it has the right key and it already works.