### PR TITLE
[tests-only] Remove redundant parameter

### DIFF
--- a/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/UserLdapGeneralContext.php
@@ -374,7 +374,6 @@ class UserLdapGeneralContext extends RawMinkContext implements Context {
 				$uid,
 				$uid,
 				null,
-				null,
 				false
 			);
 


### PR DESCRIPTION
This PR removes the redundant param that was removed by core PR: https://github.com/owncloud/core/commit/db5434574a3ba96621550c18bfce25c804d7cd8b#diff-53ecaebb4552a8c12cb891ca32d9879923ec2d0226afeda7e559b9f631a1300c

Part of: https://github.com/owncloud/QA/issues/808