### PR TITLE
Always return an int from Symfony Command execute method

### DIFF
--- a/lib/Command/CheckUser.php
+++ b/lib/Command/CheckUser.php
@@ -76,9 +76,9 @@ class CheckUser extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$uid = $input->getArgument('ocName');
 			$this->isAllowed($input->getOption('force'));
@@ -86,15 +86,16 @@ class CheckUser extends Command {
 			$exists = $this->backend->userExists($uid);
 			if ($exists === true) {
 				$output->writeln('The user is still available on LDAP.');
-				return;
+				return 0;
 			}
 
-			$output->writeln('The user does not exists on LDAP anymore.');
+			$output->writeln('The user does not exist on LDAP anymore.');
 			$output->writeln('Clean up the user\'s remnants by: ./occ user:delete "'
 				. $uid . '"');
 		} catch (\Exception $e) {
 			$output->writeln('<error>' . $e->getMessage(). '</error>');
 		}
+		return 0;
 	}
 
 	/**

--- a/lib/Command/CreateEmptyConfig.php
+++ b/lib/Command/CreateEmptyConfig.php
@@ -65,9 +65,9 @@ class CreateEmptyConfig extends Command {
 	/**
 	 * Executes the current command.
 	 *
-	 * @return null|int null or 0 if everything went fine, or an error code
+	 * @return int 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configID = $input->getArgument('configID');
 		if ($configID === null) {
 			$configPrefix = $this->helper->nextPossibleConfigurationPrefix();

--- a/lib/Command/DeleteConfig.php
+++ b/lib/Command/DeleteConfig.php
@@ -57,9 +57,9 @@ class DeleteConfig extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configPrefix = $input->getArgument('configID');
 
 		$success = $this->helper->deleteServerConfiguration($configPrefix);
@@ -68,6 +68,8 @@ class DeleteConfig extends Command {
 			$output->writeln("Deleted configuration with configID '{$configPrefix}'");
 		} else {
 			$output->writeln("Cannot delete configuration with configID '{$configPrefix}'");
+			return 1;
 		}
+		return 0;
 	}
 }

--- a/lib/Command/InvalidateCache.php
+++ b/lib/Command/InvalidateCache.php
@@ -47,7 +47,7 @@ class InvalidateCache extends Command {
 			->setDescription('invalidates the LDAP cache');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uProxyBackendsCount = $this->uProxy->getBackendCount() + 1;  // +1 for the proxy itself
 		$gProxyBackendsCount = $this->gProxy->getBackendCount() + 1;  // +1 for the proxy itself
 

--- a/lib/Command/Search.php
+++ b/lib/Command/Search.php
@@ -103,9 +103,9 @@ class Search extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$helper = new Helper();
 		$configPrefixes = $helper->getServerConfigurationPrefixes(true);
 		$ldapWrapper = new LDAP();
@@ -134,5 +134,6 @@ class Search extends Command {
 			$line = $name . ($printID ? ' ('.$id.')' : '');
 			$output->writeln($line);
 		}
+		return 0;
 	}
 }

--- a/lib/Command/SetConfig.php
+++ b/lib/Command/SetConfig.php
@@ -70,15 +70,15 @@ class SetConfig extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$helper = new Helper();
 		$availableConfigs = $helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if (!\in_array($configID, $availableConfigs)) {
 			$output->writeln("Invalid configID");
-			return;
+			return 1;
 		}
 
 		$this->setValue(
@@ -86,6 +86,7 @@ class SetConfig extends Command {
 			$input->getArgument('configKey'),
 			$input->getArgument('configValue')
 		);
+		return 0;
 	}
 
 	/**

--- a/lib/Command/ShowConfig.php
+++ b/lib/Command/ShowConfig.php
@@ -75,21 +75,22 @@ class ShowConfig extends Base {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configID = $input->getArgument('configID');
 		if ($configID !== null) {
 			$configIDs[] = $configID;
 			if (!\in_array($configIDs[0], $availableConfigs)) {
 				$output->writeln("Invalid configID");
-				return;
+				return 1;
 			}
 		} else {
 			$configIDs = $availableConfigs;
 		}
 		$this->renderConfigs($configIDs, $input, $output, $input->getOption('show-password'));
+		return 0;
 	}
 
 	/**

--- a/lib/Command/TestConfig.php
+++ b/lib/Command/TestConfig.php
@@ -72,14 +72,14 @@ class TestConfig extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|void|null
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$availableConfigs = $this->helper->getServerConfigurationPrefixes();
 		$configId = $input->getArgument('configID');
 		if (!\in_array($configId, $availableConfigs, true)) {
 			$output->writeln("Invalid configID");
-			return;
+			return 1;
 		}
 
 		$result = $this->testConfig($configId);
@@ -92,6 +92,7 @@ class TestConfig extends Command {
 		} else {
 			$output->writeln('Your LDAP server was kidnapped by aliens.');
 		}
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
Symfony 5 will require this, so be prepared.
For Symfony 4 it is optional.