### PR TITLE
[tests-only] [full-ci] Adjust drone CI of federated server

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -247,6 +247,7 @@ config = {
             ],
             "runCoreTests": True,
             "federatedServerNeeded": True,
+            "federatedServerVersion": "latest",
             "filterTags": "~@skip&&~@app-required",
             "runAllSuites": True,
             "numberOfParts": 28,
@@ -394,6 +395,7 @@ config = {
             "emailNeeded": True,
             "runCoreTests": True,
             "federatedServerNeeded": True,
+            "federatedServerVersion": "latest",
             "runAllSuites": True,
             "numberOfParts": 2,
             "filterTags": "@smokeTest&&~@skip&&~@app-required",
@@ -1490,6 +1492,7 @@ def acceptance(ctx):
         "databases": ["mariadb:10.2"],
         "esVersions": ["none"],
         "federatedServerNeeded": False,
+        "federatedServerVersion": "",
         "filterTags": "",
         "logLevel": "2",
         "emailNeeded": False,
@@ -1725,7 +1728,11 @@ def acceptance(ctx):
                         environment["S3_TYPE"] = "ceph"
                     if (testConfig["scalityS3"] != False):
                         environment["S3_TYPE"] = "scality"
+
                 federationDbSuffix = "-federated"
+
+                if len(testConfig["federatedServerVersion"]) == 0:
+                    testConfig["federatedServerVersion"] = testConfig["server"]
 
                 result = {
                     "kind": "pipeline",
@@ -1738,7 +1745,7 @@ def acceptance(ctx):
                     "steps": skipIfUnchanged(ctx, "acceptance-tests") +
                              installCore(ctx, testConfig["server"], testConfig["database"], testConfig["useBundledApp"]) +
                              installTestrunner(ctx, DEFAULT_PHP_VERSION, testConfig["useBundledApp"]) +
-                             (installFederated(testConfig["server"], phpVersionForDocker, testConfig["logLevel"], testConfig["database"], federationDbSuffix) + owncloudLog("federated") if testConfig["federatedServerNeeded"] else []) +
+                             (installFederated(testConfig["federatedServerVersion"], phpVersionForDocker, testConfig["logLevel"], testConfig["database"], federationDbSuffix) + owncloudLog("federated") if testConfig["federatedServerNeeded"] else []) +
                              installAppPhp(ctx, phpVersionForDocker) +
                              installAppJavaScript(ctx) +
                              installExtraApps(phpVersionForDocker, testConfig["extraApps"]) +
@@ -1779,7 +1786,7 @@ def acceptance(ctx):
                                 testConfig["extraServices"] +
                                 owncloudService(testConfig["server"], phpVersionForDocker, "server", dir["server"], testConfig["ssl"], testConfig["xForwardedFor"]) +
                                 ((
-                                    owncloudService(testConfig["server"], phpVersionForDocker, "federated", dir["federated"], testConfig["ssl"], testConfig["xForwardedFor"]) +
+                                    owncloudService(testConfig["federatedServerVersion"], phpVersionForDocker, "federated", dir["federated"], testConfig["ssl"], testConfig["xForwardedFor"]) +
                                     databaseServiceForFederation(testConfig["database"], federationDbSuffix)
                                 ) if testConfig["federatedServerNeeded"] else []),
                     "depends_on": [],


### PR DESCRIPTION
Fixes #789 

This changes the pipelines that have a federated server so that the federated server runs server "latest" (currently 10.12.1) with the current release of user_ldap (it gets it from the marketplace with a "php occ market" command). That ensures that the federated server has a server+app pair that is known to work.

The "local" server runs core daily-master-qa and the current branch of the user_ldap app. That has the current new code (Symfony 5 in this case) in both server core and user_ldap.

So this verifies that a "new" Symfony 5 installation with user_ldap can do federated sharing with a "latest" Symfony 4 installation - good.