### PR TITLE
Use alphabetical order instead of natural order

### DIFF
--- a/lib/Group_LDAP.php
+++ b/lib/Group_LDAP.php
@@ -739,7 +739,7 @@ class Group_LDAP implements \OCP\GroupInterface {
 				break;
 		}
 
-		\natsort($groupUsers);
+		\sort($groupUsers);
 		$this->access->getConnection()->writeToCache('usersInGroup-'.$gid.'-'.$search, $groupUsers);
 		$groupUsers = \array_slice($groupUsers, $offset, $limit);
 


### PR DESCRIPTION
Related to https://github.com/owncloud/enterprise/issues/5634.

This aligns with https://github.com/owncloud/core/pull/40840 so the users are returned alphabetically by uid