### PR TITLE
Exposed attributes

### DIFF
--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -30,3 +30,4 @@ $application = new OCA\User_LDAP\AppInfo\Application();
 $application->checkCompatibility();
 $application->registerBackends();
 $application->registerHooks();
+$application->registerEventListener();

--- a/js/wizard/wizardTabAdvanced.js
+++ b/js/wizard/wizardTabAdvanced.js
@@ -120,6 +120,10 @@ OCA = OCA || {};
 				home_folder_naming_rule: {
 					$element: $('#home_folder_naming_rule'),
 					setMethod: 'setHomeFolderAttribute'
+				},
+				ldap_exposed_attributes_for_user: {
+					$element: $('#ldap_exposed_attributes_for_user'),
+					setMethod: 'setExposedAttributesForUser'
 				}
 			};
 			this.setManagedItems(items);
@@ -348,6 +352,15 @@ OCA = OCA || {};
 		 */
 		setHomeFolderAttribute: function(attribute) {
 			this.setElementValue(this.managedItems.home_folder_naming_rule.$element, attribute);
+		},
+
+		/**
+		 * sets the user attributes that will be exposed to other apps
+		 *
+		 * @param {string} attributes
+		 */
+		setExposedAttributesForUser: function(attributes) {
+			this.setElementValue(this.managedItems.ldap_exposed_attributes_for_user.$element, attributes);
 		},
 
 		/**

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -102,7 +102,7 @@ class Application extends \OCP\AppFramework\App {
 
 		$uProxy = $container->query(User_Proxy::class);
 		$eventDispatcher = $server->getEventDispatcher();
-		$eventDispatcher->addListener(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, function(UserExtendedAttributesEvent $event) use ($uProxy) {
+		$eventDispatcher->addListener(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, function (UserExtendedAttributesEvent $event) use ($uProxy) {
 			$targetUser = $event->getUser();
 			if ($targetUser->getBackendClassName() !== 'LDAP') {
 				// If the user doesn't come from LDAP, there is nothing to do here.

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -25,6 +25,8 @@ use OCA\User_LDAP\Group_Proxy;
 use OCA\User_LDAP\Helper;
 use OCA\User_LDAP\LDAP;
 use OCA\User_LDAP\User_Proxy;
+use OCP\User\UserExtendedAttributesEvent;
+use OCA\User_LDAP\User\Manager;
 
 class Application extends \OCP\AppFramework\App {
 	/**
@@ -92,5 +94,31 @@ class Application extends \OCP\AppFramework\App {
 			$this->getContainer()->query(Helper::class),
 			'loginName2UserName'
 		);
+	}
+
+	public function registerEventListener() {
+		$container = $this->getContainer();
+		$server = $container->getServer();
+
+		$uProxy = $container->query(User_Proxy::class);
+		$eventDispatcher = $server->getEventDispatcher();
+		$eventDispatcher->addListener(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, function(UserExtendedAttributesEvent $event) use ($uProxy) {
+			$targetUser = $event->getUser();
+			if ($targetUser->getBackendClassName() !== 'LDAP') {
+				// If the user doesn't come from LDAP, there is nothing to do here.
+				return;
+			}
+
+			try {
+				$attrs = $uProxy->getExposedAttributes($targetUser->getUID());
+
+				$event->setAttributes('user_ldap_state', 'OK');
+				foreach ($attrs as $key => $value) {
+					$event->setAttributes("user_ldap_attr_{$key}", $value);
+				}
+			} catch (\Exception $e) {
+				$event->setAttributes('user_ldap_state', 'Error');
+			}
+		});
 	}
 }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -74,6 +74,7 @@ use OCP\IConfig;
  * @property string $ldapConfigurationActive,
  * @property string $ldapAttributesForUserSearch,
  * @property string $ldapAttributesForGroupSearch,
+ * @property string $ldapExposedAttributesForUser,
  * @property string $ldapExperiencedAdmin,
  * @property string $homeFolderNamingRule,
  * @property string $hasPagedResultSupport,
@@ -142,6 +143,7 @@ class Configuration {
 		'ldapConfigurationActive' => false,
 		'ldapAttributesForUserSearch' => null,
 		'ldapAttributesForGroupSearch' => null,
+		'ldapExposedAttributesForUser' => null,
 		'ldapExperiencedAdmin' => false,
 		'homeFolderNamingRule' => null,
 		'hasPagedResultSupport' => false,
@@ -257,6 +259,7 @@ class Configuration {
 				case 'ldapBaseGroups':
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
+				case 'ldapExposedAttributesForUser':
 				case 'ldapUserFilterObjectclass':
 				case 'ldapUserFilterGroups':
 				case 'ldapGroupFilterObjectclass':
@@ -288,6 +291,7 @@ class Configuration {
 					case 'ldapBaseGroups':
 					case 'ldapAttributesForUserSearch':
 					case 'ldapAttributesForGroupSearch':
+					case 'ldapExposedAttributesForUser':
 					case 'ldapUserFilterObjectclass':
 					case 'ldapUserFilterGroups':
 					case 'ldapGroupFilterObjectclass':
@@ -333,6 +337,7 @@ class Configuration {
 				case 'ldapBaseGroups':
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
+				case 'ldapExposedAttributesForUser':
 				case 'ldapUserFilterObjectclass':
 				case 'ldapUserFilterGroups':
 				case 'ldapGroupFilterObjectclass':
@@ -546,6 +551,7 @@ class Configuration {
 			'ldap_configuration_active'         => 0,
 			'ldap_attributes_for_user_search'   => '',
 			'ldap_attributes_for_group_search'  => '',
+			'ldap_exposed_attributes_for_user'  => '',
 			'ldap_expert_username_attr'         => '',
 			'ldap_expert_groupname_attr'        => '',
 			'ldap_expert_uuid_user_attr'        => '',
@@ -606,6 +612,7 @@ class Configuration {
 			'ldap_configuration_active'         => 'ldapConfigurationActive',
 			'ldap_attributes_for_user_search'   => 'ldapAttributesForUserSearch',
 			'ldap_attributes_for_group_search'  => 'ldapAttributesForGroupSearch',
+			'ldap_exposed_attributes_for_user'  => 'ldapExposedAttributesForUser',
 			'ldap_expert_username_attr'         => 'ldapExpertUsernameAttr',
 			'ldap_expert_groupname_attr'        => 'ldapExpertGroupnameAttr',
 			'ldap_expert_uuid_user_attr'        => 'ldapExpertUUIDUserAttr',

--- a/lib/Connection.php
+++ b/lib/Connection.php
@@ -74,6 +74,7 @@ use OCP\Util;
  * @property array $ldapBase
  * @property string $ldapIgnoreNamingRules
  * @property array $ldapAttributesForGroupSearch
+ * @property array $ldapExposedAttributesForUser
  * @property string $ldapExpertUUIDGroupAttr
  * @property string $uuidAttr
  * @property string $ldapUuidGroupAttribute.
@@ -337,6 +338,7 @@ class Connection extends LDAPUtility {
 				case 'ldapBaseGroups':
 				case 'ldapAttributesForUserSearch':
 				case 'ldapAttributesForGroupSearch':
+				case 'ldapExposedAttributesForUser':
 					if (\is_array($config[$configkey])) {
 						$result[$dbkey] = \implode("\n", $config[$configkey]);
 						break;
@@ -398,8 +400,11 @@ class Connection extends LDAPUtility {
 		}
 
 		//make sure empty search attributes are saved as simple, empty array
-		$saKeys = ['ldapAttributesForUserSearch',
-						'ldapAttributesForGroupSearch'];
+		$saKeys = [
+			'ldapAttributesForUserSearch',
+			'ldapAttributesForGroupSearch',
+			'ldapExposedAttributesForUser',
+		];
 		foreach ($saKeys as $key) {
 			$val = $this->configuration->$key;
 			if (\is_array($val) && \count($val) === 1 && empty($val[0])) {

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -136,6 +136,22 @@ class Manager {
 	public function getConnection() {
 		return $this->access->getConnection();
 	}
+
+	/**
+	 * Get a list with the configured exposed attributes.
+	 * The `getAttributes` method will contain these exposed attributes, and all
+	 * of them will be requested. This list is public in order to know what
+	 * attributes can be exposed to the outside.
+	 */
+	public function getExposedAttributes() {
+		$ldapConfig = $this->getConnection();
+		$exposedAttributes = $ldapConfig->ldapExposedAttributesForUser;
+		if ($exposedAttributes === '' || $exposedAttributes === null) {
+			$exposedAttributes = [];
+		}
+		return $exposedAttributes;
+	}
+
 	/**
 	 * returns a list of attributes that will be processed further, e.g. quota,
 	 * email, displayname, or others.
@@ -177,6 +193,12 @@ class Manager {
 			foreach ($this->getConnection()->uuidAttributes as $attr) {
 				$attributes[$attr] = true;
 			}
+		}
+
+		// attributes to be exposed
+		$exposedAttributes = $this->getExposedAttributes();
+		foreach ($exposedAttributes as $expAttr) {
+			$attributes[$expAttr] = true;
 		}
 
 		if ($this->ocConfig->getSystemValue('enable_avatars', true) === true && !$minimal) {

--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -334,6 +334,15 @@ class UserEntry {
 	}
 
 	/**
+	 * Get the value of the attribute or null if the attribute is missing.
+	 * Unless the attribute has an associated converter (such as objectsid,
+	 * guid and objectguid), the value will be returned unmodified.
+	 */
+	public function getAttribute($attrName) {
+		return $this->getAttributeValue($attrName, null, false);
+	}
+
+	/**
 	 * @param string $configOption
 	 * @param string $default
 	 * @return string

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -406,6 +406,30 @@ class User_LDAP implements IUserBackend, UserInterface {
 		return null;
 	}
 
+	/**
+	 * Get the exposed attributes for the user.
+	 * It will return a map with the configured attributes as keys, and the
+	 * value of those attributes as values. In case of multivalued attributes,
+	 * only the first value will be returned.
+	 *
+	 * @param string $uid
+	 * @return array<string,string>|false key -> value map containing the attributes
+	 * and their values. False if the user isn't found
+	 */
+	public function getExposedAttributes($uid) {
+		$userEntry = $this->userManager->getCachedEntry($uid);
+		if ($userEntry === null) {
+			return false;
+		}
+
+		$exposedAttrs = $this->userManager->getExposedAttributes();
+		$attrs = [];
+		foreach ($exposedAttrs as $attr) {
+			$attrs[$attr] = $userEntry->getAttribute($attr);
+		}
+		return $attrs;
+	}
+
 	public function clearConnectionCache() {
 		$this->userManager->getConnection()->clearCache();
 	}

--- a/lib/User_Proxy.php
+++ b/lib/User_Proxy.php
@@ -367,6 +367,10 @@ class User_Proxy extends Proxy implements
 		return \count($this->backends);
 	}
 
+	public function getExposedAttributes($uid) {
+		return $this->handleRequest($uid, 'getExposedAttributes', [$uid]);
+	}
+
 	public function clearFullCache($callback = null) {
 		$this->clearCache();
 		if ($callback !== null) {

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -276,6 +276,13 @@ style('user_ldap', 'settings');
 								<?php p($l->t('Leave empty for user name (default). Otherwise, specify an LDAP/AD attribute.')); ?>
 							</div>
 						</div>
+						<div class="tablerow">
+							<label for="ldap_exposed_attributes_for_user"><?php p($l->t('Exposed User Attributes')); ?></label>
+							<textarea id="ldap_exposed_attributes_for_user" name="ldap_exposed_attributes_for_user" placeholder="<?php p($l->t('Optional; one attribute per line')); ?>" data-default="<?php p($_['ldap_exposed_attributes_for_user_default']); ?>"></textarea>
+							<div class="hint">
+								<?php p($l->t('User attributes that other apps will be able to check')); ?>
+							</div>
+						</div>
 					</div>
 				</section>
 			</div>

--- a/tests/unit/User/ManagerTest.php
+++ b/tests/unit/User/ManagerTest.php
@@ -102,6 +102,8 @@ class ManagerTest extends \Test\TestCase {
 						return null;
 					case 'ldapAttributesForUserSearch':
 						return ['uidNumber'];
+					case 'ldapExposedAttributesForUser':
+						return ['homePhone', 'homePostalAddress'];
 					case 'ldapBaseUsers':
 						return 'dc=foobar,dc=bar';
 					default:
@@ -124,6 +126,12 @@ class ManagerTest extends \Test\TestCase {
 		$this->manager->setLdapAccess($this->access);
 	}
 
+	public function testGetExposedAttributes() {
+		$attributes = $this->manager->getExposedAttributes();
+		$this->assertContains('homePhone', $attributes);
+		$this->assertContains('homePostalAddress', $attributes);
+	}
+
 	public function testGetAttributesAll() {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
@@ -138,6 +146,8 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertContains('jpegphoto', $attributes);
 		$this->assertContains('thumbnailphoto', $attributes);
 		$this->assertContains('uidNumber', $attributes);
+		$this->assertContains('homePhone', $attributes);
+		$this->assertContains('homePostalAddress', $attributes);
 	}
 
 	public function testGetAttributesAvatarsDisabled() {

--- a/tests/unit/User/UserEntryTest.php
+++ b/tests/unit/User/UserEntryTest.php
@@ -626,6 +626,49 @@ class UserEntryTest extends \Test\TestCase {
 		self::assertEquals([], $userEntry->getSearchTerms());
 	}
 
+	public function testGetAttribute() {
+		$userEntry = new UserEntry(
+			$this->config,
+			$this->logger,
+			$this->connection,
+			[
+				'dn' => [0 => 'cn=foo,dc=foobar,dc=bar'],
+				'samaccountname' => [0 => 'user007'],
+				'whencreated' => [0 => '20220930084030.0Z']
+			]
+		);
+		self::assertSame('user007', $userEntry->getAttribute('samaccountname'));
+		self::assertSame('20220930084030.0Z', $userEntry->getAttribute('whencreated'));
+	}
+
+	public function testGetAttributeMissing() {
+		$userEntry = new UserEntry(
+			$this->config,
+			$this->logger,
+			$this->connection,
+			[
+				'dn' => [0 => 'cn=foo,dc=foobar,dc=bar'],
+				'samaccountname' => [0 => 'user007'],
+				'whencreated' => [0 => '20220930084030.0Z']
+			]
+		);
+		self::assertNull($userEntry->getAttribute('missingone'));
+	}
+
+	public function testGetAttributeNotTrimmed() {
+		$userEntry = new UserEntry(
+			$this->config,
+			$this->logger,
+			$this->connection,
+			[
+				'dn' => [0 => 'cn=foo,dc=foobar,dc=bar'],
+				'samaccountname' => [0 => '	user007 '],
+				'whencreated' => [0 => '20220930084030.0Z']
+			]
+		);
+		self::assertSame('	user007 ', $userEntry->getAttribute('samaccountname'));
+	}
+
 	public function testLdapEntryLowercasedKeys() {
 		$val = 'cn=foo,dc=foobar,dc=bar';
 		$input = ['Dn' => ['count' => 1, $val]];

--- a/tests/unit/User_LDAPTest.php
+++ b/tests/unit/User_LDAPTest.php
@@ -372,6 +372,30 @@ class User_LDAPTest extends \Test\TestCase {
 		$this->assertFalse($this->backend->canChangeAvatar('usertest'));
 	}
 
+	public function testGetExposedAttributes() {
+		$userEntry = $this->createMock(UserEntry::class);
+		$userEntry->method('getAttribute')
+			->willReturnMap([
+				['attr1', 'value01'],
+				['attr2', 'value02'],
+			]);
+
+		$this->manager->method('getCachedEntry')->willReturn($userEntry);
+		$this->manager->method('getExposedAttributes')->willReturn(['attr1', 'attr2']);
+
+		$expected = [
+			'attr1' => 'value01',
+			'attr2' => 'value02',
+		];
+		$this->assertSame($expected, $this->backend->getExposedAttributes('usertest'));
+	}
+
+	public function testGetExposedAttributesMissingEntry() {
+		$this->manager->method('getCachedEntry')->willReturn(null);
+
+		$this->assertFalse($this->backend->getExposedAttributes('usertest'));
+	}
+
 	public function testClearConnectionCache() {
 		$connection = $this->createMock(Connection::class);
 		$connection->expects($this->once())->method('clearCache');


### PR DESCRIPTION
Expose user attributes from LDAP to other apps.

The admin will expose some attributes for other apps to consume. For example, the admin could expose the `businessCategory`, `employeeType` and `employeeNumber` (assuming those attributes are available) so other apps can use that information.

By default, no attribute will be exposed. This means that other apps will have to use the information provided by core (check the core's `IUser` interface). The admin can add any attribute (one per line) in the user_ldap's wizard -> advanced tab -> special attributes -> exposed user attributes (at the bottom of the advanced tab).
Note that the information will be available for any app, so choose wisely what information you want to expose.

Other apps can access to those attributes via the `getExtendedAttributes` method of the `IUser` class (available since 10.11).
The recommended procedure to get the exposed LDAP attributes is:
1. Check that the current `IUser` instance is from LDAP (`$user->getBackendClassName() === 'LDAP'` should be enough)
2. Get the user's extended attributes: `$eattrs = $user->getExtendedAttributes()`
3. Check that the state of the LDAP attributes is OK. This is needed because we'll have to connect to the LDAP server and the connection could be down. `if (isset($eattrs['user_ldap_state']) && $eattrs['user_ldap_state'] === 'OK') ...`
    The `user_ldap_state` can be either `OK` if we get the attributes, or `Error` if something wrong happens. If it's `Error`, there won't be any LDAP attribute available.
    In addition, note that the `user_ldap_state` will appear only for LDAP users.
4. Once we know the state is OK, we can check whether the attribute we want is present.
    The attribute will have the following format: `user_ldap_attr_<lowercaseAttr>`, for example `user_ldap_attr_employeetype` or `user_ldap_attr_homephonenumber`

```
$user = $this->userManager->get('myUser');
if ($user->getBackendClassName() !== 'LDAP') {
  return; // abort, not LDAP user
}

$extendedAttrs = $user->getExtendedAttributes();
if (!isset($extendedAttrs['user_ldap_state']) || $extendedAttrs['user_ldap_state'] !== 'OK') {
  return; // abort because we couldn't get the LDAP attributes reliably
}

if (isset($extendedAttrs['user_ldap_attr_homephone'])) {
  printf("myUser's phone number is %s", $extendedAttrs['user_ldap_attr_homephone']);
} else {
  printf("myUser doesn't have a phone number");
}
```

Note that the information exposed isn't being used for now. It's expected that other apps document additional requirements if they need the admin to modify the user_ldap's configuration in order to expose specific attributes