### PR TITLE
[full-ci] [tests-only] Remove select-encryption-type occ command from CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -552,7 +552,6 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
-                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },
@@ -601,7 +600,6 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
-                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },
@@ -664,7 +662,6 @@ config = {
                     "commands": [
                         "cd %s" % dir["server"],
                         "php occ encryption:enable",
-                        "php occ encryption:select-encryption-type masterkey --yes",
                         "php occ config:list",
                     ],
                 },


### PR DESCRIPTION
Fixes #803 

Remove select-encryption-type from the drone CI pipelines that run with core latest plus encryption and user_ldap.

core latest is now 10.13.0, and in 10.13.0 the select-encryption-type command was removed. Encryption now always defaults to masterkey.