### PR TITLE
fix: search terms for binary fields will be converted if possible

### DIFF
--- a/lib/User/UserEntry.php
+++ b/lib/User/UserEntry.php
@@ -314,6 +314,7 @@ class UserEntry {
 	 * @return string[]
 	 */
 	public function getSearchTerms() {
+		$converterHub = ConverterHub::getDefaultConverterHub();
 		$rawAttributes = $this->connection->ldapAttributesForUserSearch;
 		$attributes = empty($rawAttributes) ? [] : $rawAttributes;
 		// Get from LDAP if we don't have it already
@@ -321,7 +322,11 @@ class UserEntry {
 		foreach ($attributes as $attr) {
 			$attr = \strtolower($attr);
 			if (isset($this->ldapEntry[$attr])) {
+				$mustConvert = $converterHub->hasConverter($attr);
 				foreach ($this->ldapEntry[$attr] as $value) {
+					if ($mustConvert) {
+						$value = $converterHub->bin2str($attr, $value);
+					}
 					$value = \trim($value);
 					if (!empty($value)) {
 						$searchTerms[\strtolower($value)] = true;

--- a/tests/unit/User/UserEntryTest.php
+++ b/tests/unit/User/UserEntryTest.php
@@ -610,6 +610,23 @@ class UserEntryTest extends \Test\TestCase {
 		self::assertEquals(['a@b.c', 'alt@b.c', 'foo'], $userEntry->getSearchTerms());
 	}
 
+	public function testGetSearchTermsWithConversion() {
+		$this->connection->expects($this->once())
+			->method('__get')
+			->with($this->equalTo('ldapAttributesForUserSearch'))
+			->will($this->returnValue(['objectguid']));  // objectguid is converted by default
+		$userEntry = new UserEntry(
+			$this->config,
+			$this->logger,
+			$this->connection,
+			[
+				'dn' => [0 => 'cn=foo,dc=foobar,dc=bar'],
+				'objectguid' => [0 => "\xf3\x71\xe2\x36\xa9\x48\x63\x4e\xb6\xbd\x41\xb6\x9d\x9b\x59\xb3"], // all mails should be found
+			]
+		);
+		self::assertEquals(['36e271f3-48a9-4e63-b6bd-41b69d9b59b3'], $userEntry->getSearchTerms());
+	}
+
 	public function testGetSearchTermsUnconfigured() {
 		$this->connection->expects($this->once())
 			->method('__get')


### PR DESCRIPTION
Related to https://github.com/owncloud/enterprise/issues/6032

The app will take care of converting binary attributes when searching for them.

For example, if the user_ldap app has been configured the "user search attributes" with "objectguid" (among other attributes), searching by "36E271F3" might return results, assuming the converted value we have from binary contains those characters.
Note that the converted value will also be stored as search term for the account in the "oc_account_terms" table.