### PR TITLE
fix: do no hit LDAP if no exposed attribute is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased] - xxxx-xx-xx
 
+### Fixed
+
+- [#823](https://github.com/owncloud/user_ldap/pull/823) - Don't hit the LDAP server if no exposed attribute is configured
 
 
 ## [0.19.0] - 2024-01-18

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -111,6 +111,13 @@ class Application extends \OCP\AppFramework\App {
 
 			try {
 				$attrs = $uProxy->getExposedAttributes($targetUser->getUID());
+				if ($attrs === null || $attrs === false) {
+					// either there are no exposed attributes or the user isn't found in LDAP
+					// if there are no exposed attributes configured, we won't contact the LDAP server,
+					// so we don't know if the user really exists.
+					$event->setAttributes('user_ldap_state', 'Unknown');
+					return;
+				}
 
 				$event->setAttributes('user_ldap_state', 'OK');
 				foreach ($attrs as $key => $value) {

--- a/lib/User/Manager.php
+++ b/lib/User/Manager.php
@@ -142,6 +142,7 @@ class Manager {
 	 * The `getAttributes` method will contain these exposed attributes, and all
 	 * of them will be requested. This list is public in order to know what
 	 * attributes can be exposed to the outside.
+	 * @return string[]
 	 */
 	public function getExposedAttributes() {
 		$ldapConfig = $this->getConnection();

--- a/lib/User_LDAP.php
+++ b/lib/User_LDAP.php
@@ -413,16 +413,21 @@ class User_LDAP implements IUserBackend, UserInterface {
 	 * only the first value will be returned.
 	 *
 	 * @param string $uid
-	 * @return array<string,string>|false key -> value map containing the attributes
-	 * and their values. False if the user isn't found
+	 * @return array<string,string>|false|null key -> value map containing the
+	 * attributes and their values. False if the user isn't found. Null if no
+	 * attribute is configured
 	 */
 	public function getExposedAttributes($uid) {
+		$exposedAttrs = $this->userManager->getExposedAttributes();
+		if (\count($exposedAttrs) === 0) {
+			return null;
+		}
+
 		$userEntry = $this->userManager->getCachedEntry($uid);
 		if ($userEntry === null) {
 			return false;
 		}
 
-		$exposedAttrs = $this->userManager->getExposedAttributes();
 		$attrs = [];
 		foreach ($exposedAttrs as $attr) {
 			$attrs[$attr] = $userEntry->getAttribute($attr);

--- a/tests/unit/User_LDAPTest.php
+++ b/tests/unit/User_LDAPTest.php
@@ -392,8 +392,16 @@ class User_LDAPTest extends \Test\TestCase {
 
 	public function testGetExposedAttributesMissingEntry() {
 		$this->manager->method('getCachedEntry')->willReturn(null);
+		$this->manager->method('getExposedAttributes')->willReturn(['attr1']);
 
 		$this->assertFalse($this->backend->getExposedAttributes('usertest'));
+	}
+
+	public function testGetExposedAttributesNoAttrConfigured() {
+		$this->manager->method('getCachedEntry')->willReturn(null);
+		$this->manager->method('getExposedAttributes')->willReturn([]);
+
+		$this->assertNull($this->backend->getExposedAttributes('usertest'));
 	}
 
 	public function testClearConnectionCache() {


### PR DESCRIPTION
If there are no exposed attributes configured in the ldap's wizard, we shouldn't hit the LDAP server trying to get the exposed attributes.

Link: https://github.com/owncloud/enterprise/issues/6856