### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,32 +1,132 @@
-# LDAP Integration
+# LDAP Integration (user_ldap)
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/user_ldap/status.svg?branch=master)](https://drone.owncloud.com/owncloud/user_ldap)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_user_ldap&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_user_ldap)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_user_ldap&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_user_ldap)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_user_ldap&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_user_ldap)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-## Running Tests
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-PHPUnit tests: `make test-php`
+The LDAP Integration app connects ownCloud Server to LDAP and Active Directory services for user authentication and group management. It synchronizes users and groups from the directory server, supports multiple LDAP connections and provides configurable attribute mapping, enabling organizations to integrate ownCloud seamlessly with their existing identity infrastructure.
 
-#### Additional configuration options that can be added to config.php
+## Part of Classic (OC10)
 
-* `'user_ldap.enable_medial_search' => true`
+This app is a core component of the [ownCloud Server (OC10)](https://github.com/owncloud/core) authentication stack. It provides the primary enterprise authentication mechanism, connecting ownCloud to LDAP servers (such as OpenLDAP) and Microsoft Active Directory.
 
-    By default, when you search for a user your input string will match the beginning of the username. For example, if your LDAP server has "erl" and "peter" as users and you search with "er", only "erl" will be shown.
+The ownCloud Server is available on [Docker Hub](https://hub.docker.com/r/owncloud/server).
 
-    Enabling this option allows you to overcome this limitation. In the example above, when this option is active, searching for "er" will find both users.
+## Getting Started
 
-    Before enabling this option take into account the following things:
+Follow the steps below to enable and configure LDAP integration.
 
-    * This option affects all LDAP connections. It isn't possible to enable this option for a specific connection.
-    * This option could have a performance impact on big LDAP installations. Check your LDAP provider how to enable indexes for medial searches if they're supported but not active.
-    * The option will work regardless of whether the LDAP server has an index for this. Small LDAP installations could have an acceptable performance with this option active even if the LDAP doesn't have that index active.
+### Installation
 
-#### Additional configuration options that can be modified via occ configurations 
+The LDAP app is bundled with ownCloud Server. Enable it via:
 
-The user_ldap app  will check for updated attributes at every user login. Attributes like mail oder quota are retrieved from the ldap server. To save resources on the ldap server, there is a minimum time between two updates for every user. Without modification, the update interval is not more often then 86400 seconds (1 day). This can be modified by setting the app config 'updateAttributesInterval' to any number you like. Setting this value to 0 will update on very login request which can be quiet often and stress your ldap server.
-Attributes are unlikely to change very often, but waiting a day for a new quota is maybe a little bit long.
+```bash
+php occ app:enable user_ldap
+```
 
-To allow modifications of minimum time between checks to one hour (3600 seconds) you can do this via occ:
-```occ config:app:set user_ldap updateAttributesInterval  --value=3600 ```
+### Running Tests
+
+```bash
+make test-php-unit         # Run PHP unit tests
+make test-php-style        # Check code style
+make test-php-phpstan      # Run PHPStan static analysis
+make test-acceptance-api   # Run LDAP API acceptance tests
+make test-acceptance-cli   # Run LDAP CLI acceptance tests
+```
+
+### Configuration Options
+
+Add to `config.php` for medial (substring) search:
+
+```php
+'user_ldap.enable_medial_search' => true
+```
+
+Configure attribute update interval via `occ`:
+
+```bash
+occ config:app:set user_ldap updateAttributesInterval --value=3600
+```
+
+## Documentation
+
+- [LDAP Integration Documentation](https://doc.owncloud.com/server/latest/admin_manual/configuration/user/user_auth_ldap.html)
+- [ownCloud Server Admin Manual](https://doc.owncloud.com/server/latest/admin_manual/)
+
+## Community & Support
+
+**[Star](https://github.com/owncloud/user_ldap)** this repo and **Watch** for release notifications!
+
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
+
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](LICENSE).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ make test-php-style        # Check code style
 make test-php-phpstan      # Run PHPStan static analysis
 make test-acceptance-api   # Run LDAP API acceptance tests
 make test-acceptance-cli   # Run LDAP CLI acceptance tests
+make test-acceptance-webui # Run LDAP WebUI acceptance tests
 ```
 
 ### Configuration Options

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,87 @@
+# agents.md — user_ldap
+
+## Repository Overview
+
+The LDAP Integration app connects ownCloud Server to LDAP and Active Directory for user authentication and group management. Supports multiple LDAP connections, configurable attribute mapping, and medial search.
+
+- **Classification:** Classic (OC10)
+- **Activity Status:** Active
+- **License:** AGPL-3.0
+- **Language:** PHP, JavaScript
+
+## Architecture & Key Paths
+
+- `appinfo/` — ownCloud app metadata (info.xml, routes)
+- `lib/` — PHP backend (LDAP connection, user/group providers, attribute mapping)
+- `js/` — Frontend JavaScript (settings UI)
+- `css/` — Stylesheets
+- `l10n/` — Localization/translation files
+- `templates/` — PHP templates for LDAP configuration UI
+- `tests/` — PHPUnit and acceptance tests
+- `Makefile` — Build and test orchestration
+- `composer.json` — PHP dependencies
+- `package.json` — JavaScript dependencies
+- `phpcs.xml` — Code style configuration
+- `phpstan.neon` — Static analysis configuration
+
+## Development Conventions
+
+- Standard ownCloud OC10 app structure
+- Code style enforced by phpcs
+- PHPStan for static analysis
+- SonarCloud integration
+- Bower for legacy JS dependencies (`bower.json`)
+
+## Build & Test Commands
+
+```bash
+make all                    # Install all dependencies (Bower + Composer)
+make dist                   # Build distribution package
+make clean                  # Clean build artifacts
+make test-php-unit          # Run PHP unit tests
+make test-php-style         # Check code style (phpcs)
+make test-php-style-fix     # Auto-fix style issues
+make test-php-phpstan       # Run PHPStan
+make test-php-phan          # Run Phan
+make test-acceptance-api    # Run LDAP API acceptance tests
+make test-acceptance-cli    # Run LDAP CLI acceptance tests
+make test-acceptance-webui  # Run LDAP webUI acceptance tests
+make test-acceptance-core-api    # Run core API acceptance tests
+make test-acceptance-core-cli    # Run core CLI acceptance tests
+make test-acceptance-core-webui  # Run core webUI acceptance tests
+```
+
+## Important Constraints
+
+- **AGPL-3.0 copyleft license:** The OSPO Apache 2.0 migration requires auditing this copyleft license and all contributor agreements.
+- **Not compatible with user_external:** Cannot be used alongside the `user_external` WebDAV authentication backend.
+- **LDAP server dependency:** Requires a running LDAP or Active Directory server.
+- **Performance considerations:** Medial search (`user_ldap.enable_medial_search`) may impact performance on large LDAP installations without proper indexing.
+- **Attribute update interval:** Configurable via `updateAttributesInterval` app config (default: 86400 seconds / 1 day).
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+
+- This is an ownCloud Server (OC10) app, not an oCIS extension. oCIS has its own LDAP integration.
+- The `lib/` directory contains LDAP connection management, user/group providers and attribute mapping.
+- Configuration is done through the ownCloud admin settings UI and `config.php`.
+- Multiple LDAP server connections are supported.
+- The app syncs users and groups from LDAP to the local ownCloud database.


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>