### PR TITLE
fix: escape wildcards and control bytes in LDAP filter parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
 - [#844](https://github.com/owncloud/user_ldap/pull/844) - Strip control characters from the LDAP bind DN and the search filters
+- [#846](https://github.com/owncloud/user_ldap/pull/846) - Escape wildcards and control characters in user-supplied LDAP filter parts
 
 
 ## [0.20.1] - 2026-07-22

--- a/lib/Access.php
+++ b/lib/Access.php
@@ -1470,9 +1470,20 @@ class Access implements IUserTools {
 			$asterisk = '*';
 			$input = \mb_substr($input, 1, null, 'UTF-8');
 		}
-		$search  = ['*', '\\', '(', ')'];
-		$replace = ['\\*', '\\\\', '\\(', '\\)'];
-		return $asterisk . \str_replace($search, $replace, $input);
+		// Escape in a single pass using the RFC 4515 section 3 hex form. A
+		// sequential str_replace() re-escapes the backslashes it just added
+		// itself, which left the wildcard live ('*' became '\\*' - an escaped
+		// backslash followed by a raw asterisk). Control characters are covered
+		// by the same pattern: RFC 4515 requires them to be escaped and they
+		// would otherwise be smuggled onto the wire verbatim.
+		// Deliberately byte-wise, so invalid UTF-8 cannot make this return null.
+		return $asterisk . \preg_replace_callback(
+			'/[*\\\\()\x00-\x1f\x7f]/',
+			static function ($match) {
+				return \sprintf('\\%02x', \ord($match[0]));
+			},
+			$input
+		);
 	}
 
 	/**

--- a/tests/unit/AccessTest.php
+++ b/tests/unit/AccessTest.php
@@ -95,9 +95,39 @@ class AccessTest extends \Test\TestCase {
 	public function escapeFilterPartDataProvider() {
 		return [
 			['okay', 'okay'],
-			['*', '\\\\*'], // escape wildcard
-			['foo*bar', 'foo\\\\*bar'], // escape wildcard in valid chars
+			['*', '\\2a'], // escape wildcard
+			['foo*bar', 'foo\\2abar'], // escape wildcard in valid chars
+			['foo\\bar', 'foo\\5cbar'], // escape backslash
+			['(uid=foo)', '\\28uid=foo\\29'], // escape parentheses
+			['\\2a', '\\5c2a'], // an already escaped wildcard must not stay live
+			["foo\r\nbar", 'foo\\0d\\0abar'], // escape CRLF
+			["foo\x00bar", 'foo\\00bar'], // escape NUL
+			["foo\x7fbar", 'foo\\7fbar'], // escape DEL
+			["foo\tbar", 'foo\\09bar'], // escape TAB
+			['cn=Müller', 'cn=Müller'], // UTF-8 must survive
 		];
+	}
+
+	/**
+	 * the asterisk of a leading wildcard search is preserved, everything else
+	 * is still escaped
+	 */
+	public function testEscapeFilterPartAllowAsterisk() {
+		$this->assertSame('*foo', $this->access->escapeFilterPart('*foo', true));
+		$this->assertSame('*foo\\2abar', $this->access->escapeFilterPart('*foo*bar', true));
+		$this->assertSame('*foo\\0d\\0abar', $this->access->escapeFilterPart("*foo\r\nbar", true));
+	}
+
+	/**
+	 * @dataProvider escapeFilterPartDataProvider
+	 * @param $input string
+	 */
+	public function testEscapeFilterPartLeavesNoLiveWildcard($input) {
+		$this->assertStringNotContainsString(
+			'*',
+			$this->access->escapeFilterPart($input),
+			'no raw asterisk may survive escaping'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #845.

`Access::escapeFilterPart()` is the escaping applied to user-supplied values before they are
substituted into an LDAP search filter. It had two defects.

### 1. Wildcards were not neutralized — the escape order was inverted

`str_replace()` with array arguments applies its replacements **sequentially**, so `*` → `\*` ran
first and the following `\` → `\\` pass re-escaped the backslash it had just introduced:

```
escapeFilterPart('*')       === '\\*'         bytes: 5c 5c 2a
escapeFilterPart('foo*bar') === 'foo\\*bar'
```

That is an *escaped backslash* followed by a **raw, still active `0x2a`**. The existing unit test at
`tests/unit/AccessTest.php:98` pinned this broken output as expected, comment `// escape wildcard`
and all.

Impact, stated conservatively: the stray literal backslash in front means `(uid=\\*)` tends to
*under*-match rather than match everything, since real uids don't start with a backslash. So this is
a correctness defect rather than a demonstrated authentication bypass — but the function's one
documented job was not being done.

### 2. Control bytes passed through untouched

Only `* \ ( )` were handled. RFC 4515 §3 requires control characters to be escaped too; they reached
`ldap_search()` verbatim via the login filter:

```php
// lib/Access.php:735-736
$loginName = $this->escapeFilterPart($loginName);
$filter = \str_replace('%uid', $loginName, $this->connection->ldapLoginFilter);
```

That path is reachable **pre-authentication** by anyone who can post to the login form
(`User\Manager::getLDAPUserByLoginName()` → `fetchUsersByLoginName()`). #844 closed the
*admin-authored* half of this class; this PR closes the *user-supplied* half.

### The fix

A single `preg_replace_callback()` pass emitting the RFC 4515 §3 hex form. It cannot re-escape its
own output, and it covers the control range in the same character class. The pattern is deliberately
byte-wise (no `/u`) so invalid UTF-8 in an attacker-controlled login name cannot make it return
`null`.

| input | before | after |
|---|---|---|
| `okay` | `okay` | `okay` |
| `*` | `\\*` (live wildcard) | `\2a` |
| `foo*bar` | `foo\\*bar` (live wildcard) | `foo\2abar` |
| `(uid=foo)` | `\(uid=foo\)` | `\28uid=foo\29` |
| `Müller` | `Müller` | `Müller` |
| CR/LF | passed through | `\0d\0a` |
| NUL / DEL / TAB | passed through | `\00` / `\7f` / `\09` |
| `*foo` (`$allowAsterisk`) | `*foo` | `*foo` |

### No search regression

In `getFilterPartForSearch()` the trailing wildcard is appended by `prepareSearchTerm()`
(`lib/Access.php:1613`) **after** `escapeFilterPart()` has run, so prefix search (`term*`) and medial
search keep working. Only *user-supplied* interior asterisks stop being live, which is the function's
documented intent.

### Deliberately not in this PR

The `%uid` substitutions that never called `escapeFilterPart()` at all — `lib/Group_LDAP.php:141`,
`:709`, `:844` (memberUid values read back from the directory) and `lib/Wizard.php:660`. Escaping
those changes group-membership resolution for every `memberUid` deployment, which doesn't belong in a
patch release; it needs its own change with acceptance-test coverage. Noted in #845.

### Tests

`escapeFilterPartDataProvider` corrected (it encoded the bug) and extended: backslash, parentheses,
an already-escaped wildcard, CR/LF, NUL, DEL, TAB, UTF-8 survival. Added
`testEscapeFilterPartAllowAsterisk` for the leading-wildcard path and
`testEscapeFilterPartLeavesNoLiveWildcard`, which asserts no raw `*` survives any provider case.

Full unit suite green locally: **249 tests, 533 assertions**. `make test-php-style` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
