### PR TITLE
chore: bump version to 0.20.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased] - XXXX-XX-XX
 
+
+## [0.20.2] - 2026-07-27
+
 ### Fixed
 
 - [#844](https://github.com/owncloud/user_ldap/pull/844) - Strip control characters from the LDAP bind DN and the search filters
@@ -230,7 +233,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add hint for max search term length - [#105](https://github.com/owncloud/user_ldap/issues/105)
 - Allow proxy to check next server - [#101](https://github.com/owncloud/user_ldap/issues/101)
 
-[Unreleased]: https://github.com/owncloud/user_ldap/compare/v0.20.1..master
+[Unreleased]: https://github.com/owncloud/user_ldap/compare/v0.20.2..master
+[0.20.2]: https://github.com/owncloud/user_ldap/compare/v0.20.1..v0.20.2
 [0.20.1]: https://github.com/owncloud/user_ldap/compare/v0.20.0..v0.20.1
 [0.20.0]: https://github.com/owncloud/user_ldap/compare/v0.19.1..v0.20.0
 [0.19.1]: https://github.com/owncloud/user_ldap/compare/v0.19.0...v0.19.1

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 	</description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Tom Needham, Juan Pablo Villafañez Ramos, Dominik Schmidt and Arthur Schiwon</author>
-	<version>0.20.1</version>
+	<version>0.20.2</version>
 	<types>
 		<authentication/>
 	</types>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_user_ldap
-sonar.projectVersion=0.19.1
+sonar.projectVersion=0.20.2
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
Prepares the 0.20.2 patch release for oc11 (11.0.0).

Contents of the release — both already on `master`:

- #844 — strip control characters from the LDAP bind DN and the configured search filters
- #846 — escape wildcards and control characters in user-supplied LDAP filter parts

Changes here:

- `appinfo/info.xml` — `0.20.1` → `0.20.2`
- `CHANGELOG.md` — promote the Unreleased block to `[0.20.2]` and add the compare link refs
- `sonar-project.properties` — `sonar.projectVersion` `0.19.1` → `0.20.2`; it had drifted, having been missed at both 0.20.0 and 0.20.1

The residual LDAP-injection surface that #844/#846 do **not** close (unescaped `%uid` from
directory-supplied `memberUid`, other directory-supplied values in filters, the attribute-name
config keys, and the absent RFC 4514 DN escaping) is tracked separately for 11.0.1 — it is
admin-authenticated or directory-controlled, so it does not belong in a patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
