### PR TITLE
feat: publish a signed release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: owncloud/reusable-workflows/.github/workflows/release.yml@main
+    with:
+      app-name: user_ldap
+    secrets:
+      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+      SIGNING_CERT: ${{ secrets.SIGNING_CERT }}
+      SIGNING_CHAIN: ${{ secrets.SIGNING_CHAIN }}


### PR DESCRIPTION
## What

Adds a `Release` workflow: on a `v*` tag push, `make dist` runs, the bundle is
signed, and the tarball is attached to a GitHub Release. Delegates to
[`owncloud/reusable-workflows`](https://github.com/owncloud/reusable-workflows/pull/87).

## Why

`make dist` in CI has been silently producing **unsigned** tarballs. `CAN_SIGN`
is only set when key, cert *and* `occ` all exist locally, so the `else` branch
just echoes a message and the build still exits 0:

```
$ make dist
Skipping signing, either no key and certificate found in ... or occ can not be found
$ tar tzf build/<app>.tar.gz | grep -c signature.json
0
$ echo $?
0
```

Signing is **mandatory on ownCloud 11+** — an unsigned app is blocked, not
warned. Signing now uses [`ocsign`](https://github.com/owncloud/ocsign), which
needs no ownCloud server, and the reusable workflow **asserts** the tarball
carries a valid `appinfo/signature.json` whose leaf `CN` matches the app id.

## Before this can publish

The `SIGNING_KEY`, `SIGNING_CERT` and `SIGNING_CHAIN` secrets must be set on
this repository. Without them the release job fails fast with a clear message
rather than shipping something unsigned.

The workflow also requires the pushed tag (minus the leading `v`) to equal
`<version>` in `appinfo/info.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
