### PR TITLE
chore: bump version to 0.20.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased] - XXXX-XX-XX
 
+
+## [0.20.3] - 2026-07-28
+
 ### Fixed
 
 - [#849](https://github.com/owncloud/user_ldap/pull/849) - Confine the LDAP home folder naming rule to the data directory
@@ -237,7 +240,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 - Add hint for max search term length - [#105](https://github.com/owncloud/user_ldap/issues/105)
 - Allow proxy to check next server - [#101](https://github.com/owncloud/user_ldap/issues/101)
 
-[Unreleased]: https://github.com/owncloud/user_ldap/compare/v0.20.2..master
+[Unreleased]: https://github.com/owncloud/user_ldap/compare/v0.20.3..master
+[0.20.3]: https://github.com/owncloud/user_ldap/compare/v0.20.2..v0.20.3
 [0.20.2]: https://github.com/owncloud/user_ldap/compare/v0.20.1..v0.20.2
 [0.20.1]: https://github.com/owncloud/user_ldap/compare/v0.20.0..v0.20.1
 [0.20.0]: https://github.com/owncloud/user_ldap/compare/v0.19.1..v0.20.0

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -14,7 +14,7 @@ More information is available in the [LDAP User and Group Backend documentation]
 	</description>
 	<licence>AGPL</licence>
 	<author>Jörn Friedrich Dreyer, Tom Needham, Juan Pablo Villafañez Ramos, Dominik Schmidt and Arthur Schiwon</author>
-	<version>0.20.2</version>
+	<version>0.20.3</version>
 	<types>
 		<authentication/>
 	</types>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_user_ldap
-sonar.projectVersion=0.20.2
+sonar.projectVersion=0.20.3
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================


### PR DESCRIPTION
Cuts 0.20.3, which ships the LDAP home-folder naming-rule fix from #849.

- `appinfo/info.xml` 0.20.2 → 0.20.3
- `sonar-project.properties` `sonar.projectVersion` 0.20.2 → 0.20.3
- `CHANGELOG.md`: `[Unreleased]` closed out as `[0.20.3] - 2026-07-28`, link refs updated

No CI change needed — the signed release workflow caller is already on `master`, so
tagging `v0.20.3` after merge builds, G2-signs and publishes `user_ldap.tar.gz`
automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)